### PR TITLE
bugfix for available dateparts for redshift/snowflake

### DIFF
--- a/macros/calendar_date/iso_week_end.sql
+++ b/macros/calendar_date/iso_week_end.sql
@@ -9,10 +9,10 @@
 {%- endmacro %}
 
 {%- macro default__iso_week_end(date) -%}
-{{ dbt_date._iso_week_end(date, 'isoweek') }}
+{{ dbt_date._iso_week_end(date, 'week') }}
 {%- endmacro %}
 
 {%- macro snowflake__iso_week_end(date) -%}
-{{ dbt_date._iso_week_end(date, 'weekiso') }}
+{{ dbt_date._iso_week_end(date, 'week') }}
 {%- endmacro %}
 

--- a/macros/calendar_date/iso_week_of_year.sql
+++ b/macros/calendar_date/iso_week_of_year.sql
@@ -8,7 +8,7 @@ cast({{ dbt_date.date_part(week_type, date) }} as {{ dbt_utils.type_int() }})
 {%- endmacro %}
 
 {%- macro default__iso_week_of_year(date) -%}
-{{ dbt_date._iso_week_of_year(date, 'isoweek') }}
+{{ dbt_date._iso_week_of_year(date, 'week') }}
 {%- endmacro %}
 
 {%- macro snowflake__iso_week_of_year(date) -%}

--- a/macros/calendar_date/iso_week_start.sql
+++ b/macros/calendar_date/iso_week_start.sql
@@ -8,7 +8,7 @@ cast({{ dbt_utils.date_trunc(week_type, date) }} as date)
 {%- endmacro %}
 
 {%- macro default__iso_week_start(date) -%}
-{{ dbt_date._iso_week_start(date, 'isoweek') }}
+{{ dbt_date._iso_week_start(date, 'week') }}
 {%- endmacro %}
 
 {%- macro snowflake__iso_week_start(date) -%}

--- a/packages.yml
+++ b/packages.yml
@@ -1,5 +1,5 @@
 packages:
-  - package: fishtown-analytics/dbt_utils
-    version: [">=0.6.0", "<0.7.0"]
+  - package: dbt-labs/dbt_utils
+    version: [">=0.7.0", "<0.8.0"]
   - package: fishtown-analytics/spark_utils
     version: 0.1.0


### PR DESCRIPTION
A minor fix for iso_* dates.

You see Redshift doesn't support isoweek datepart:
https://docs.aws.amazon.com/redshift/latest/dg/r_Dateparts_for_datetime_functions.html

Neither does Snowflake except for  DATE_PART function:
https://docs.snowflake.com/en/sql-reference/functions-date-time.html

> Database Error in model dim_calendar (models/marts/dim/dim_calendar.sql)
>   Invalid datetime part for DATE_TRUNC().
>   DETAIL:  
>     -----------------------------------------------
>     error:  Invalid datetime part for DATE_TRUNC().
>     code:      8001
>     context:   
>     query:     760488
>     location:  datetime_ops.cpp:40
>     process:   padbmaster [pid=6610]
>     -----------------------------------------------

