### PR TITLE
Change from date() to cast( as date)

### DIFF
--- a/macros/get_base_dates.sql
+++ b/macros/get_base_dates.sql
@@ -20,7 +20,7 @@ with date_spine as
 
 )
 select
-    date(d.date_day) as date_day
+    cast(d.date_day as date) as date_day
 from
     date_spine d
 {% endmacro %}


### PR DESCRIPTION
The date() function doesn't exist in T-SQL
Rather than developing a brand new macro for T-SQL this should work for all engines