### PR TITLE
reduce code footprint

### DIFF
--- a/macros/calendar_date/week_end.sql
+++ b/macros/calendar_date/week_end.sql
@@ -11,8 +11,3 @@
 {%- set dt = dbt_date.week_start(date) -%}
 {{ dbt_date.n_days_away(6, dt) }}
 {%- endmacro %}
-
-{%- macro postgres__week_end(date) -%}
-{%- set dt = dbt_date.week_start(date) -%}
-{{ dbt_date.n_days_away(6, dt) }}
-{%- endmacro %}


### PR DESCRIPTION
`defauit__week_end()` references `dbt_utils.last_day`, which itself already has a `postgres__last_day()`.

partially fixes: #20.