### PR TITLE
Removes spark-utils and updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@ packages:
 
 Note: we no longer include `spark_utils` in this package to avoid versioning conflicts. If you are running this package on non-core (Snowflake, BigQuery, Redshift, Postgres) platforms, you will need to use a package like `spark_utils` to shim macros.
 
-For example, in `dbt_project.yml`:
+For example, in `packages.yml`, you will need to include the relevant package:
+
+```yaml
+  - package: fishtown-analytics/spark_utils
+    version: <latest or range>
+```
+
+And reference in the dispatch list for `dbt_utils` in `dbt_project.yml`:
 ```yaml
 vars:
     dbt_utils_dispatch_list: [spark_utils]

--- a/README.md
+++ b/README.md
@@ -5,11 +5,19 @@ FYI: this package includes [**dbt-utils**](https://github.com/fishtown-analytics
 
 Include in `packages.yml`
 
-```
+```yaml
 packages:
   - package: calogica/dbt_date
     version: [">=0.2.0", "<0.3.0"]
     # <see https://github.com/calogica/dbt-date/releases/latest> for the latest version tag
+```
+
+Note: we no longer include `spark_utils` in this package to avoid versioning conflicts. If you are running this package on non-core (Snowflake, BigQuery, Redshift, Postgres) platforms, you will need to use a package like `spark_utils` to shim macros.
+
+For example, in `dbt_project.yml`:
+```yaml
+vars:
+    dbt_utils_dispatch_list: [spark_utils]
 ```
 
 ## Variables

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -23,7 +23,6 @@ require-dbt-version: ">=0.18.1"
 
 vars:
     'dbt_date:time_zone': 'America/Los_Angeles'
-    dbt_utils_dispatch_list: [spark_utils]
 
 quoting:
     database: false

--- a/packages.yml
+++ b/packages.yml
@@ -1,5 +1,3 @@
 packages:
   - package: fishtown-analytics/dbt_utils
     version: [">=0.6.0", "<0.7.0"]
-  - package: fishtown-analytics/spark_utils
-    version: 0.1.0


### PR DESCRIPTION
Removes dependency on `spark-utils`.

Users running this package on non-core (Snowflake, BigQuery, Redshift, Postgres) platforms, will need to use a package like `spark_utils` to shim macros.

For example, in dbt_project.yml:
```yaml
vars:
    dbt_utils_dispatch_list: [spark_utils]
```