### PR TITLE
simplify shimming

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -20,6 +20,7 @@ clean-targets:
 require-dbt-version: ">=0.18.1"
 
 vars:
+    dbt_date_dispatch_list: ['dbt_date_integration_tests']
     "dbt_date:time_zone": "America/Los_Angeles"
 
 quoting:

--- a/integration_tests/macros/_get_utils_namespaces.sql
+++ b/integration_tests/macros/_get_utils_namespaces.sql
@@ -1,4 +1,0 @@
-{% macro _get_utils_namespaces() %}
-  {% set override_namespaces = var('dbt_date_integration_tests_dispatch_list', []) %}
-  {% do return(override_namespaces + ['dbt_date_integration_tests']) %}
-{% endmacro %}

--- a/integration_tests/macros/get_test_dates.sql
+++ b/integration_tests/macros/get_test_dates.sql
@@ -42,7 +42,7 @@ select
 {%- endmacro %}
 
 {% macro get_test_week_of_year() -%}
-    {{ return(adapter.dispatch('get_test_week_of_year', packages = dbt_date_integration_tests._get_utils_namespaces()) ()) }}
+    {{ return(adapter.dispatch('get_test_week_of_year', packages = dbt_date._get_utils_namespaces()) ()) }}
 {%- endmacro %}
 
 {% macro default__get_test_week_of_year() -%}

--- a/integration_tests/macros/get_test_dates.sql
+++ b/integration_tests/macros/get_test_dates.sql
@@ -1,8 +1,4 @@
 {% macro get_test_dates() -%}
-    {{ return(adapter.dispatch('get_test_dates', packages = dbt_date_integration_tests._get_utils_namespaces()) ()) }}
-{%- endmacro %}
-
-{% macro default__get_test_dates() -%}
 select
     cast('2020-11-29' as date) as date_day,
     cast('2020-11-28' as date) as prior_date_day,
@@ -15,7 +11,7 @@ select
     334 as day_of_year,
     cast('2020-11-29' as date) as week_start_date,
     cast('2020-12-05' as date) as week_end_date,
-    48 as week_of_year,
+    {{ get_test_week_of_year()[0] }} as week_of_year,
     -- in ISO terms, this is the end of the prior week
     cast('2020-11-23' as date) as iso_week_start_date,
     cast('2020-11-29' as date) as iso_week_end_date,
@@ -37,8 +33,7 @@ select
     336 as day_of_year,
     cast('2020-11-29' as date) as week_start_date,
     cast('2020-12-05' as date) as week_end_date,
-    48 as week_of_year,
-
+    {{ get_test_week_of_year()[1] }}  as week_of_year,
     cast('2020-11-30' as date) as iso_week_start_date,
     cast('2020-12-06' as date) as iso_week_end_date,
     49 as iso_week_of_year,
@@ -46,47 +41,18 @@ select
     'Dec' as month_name_short
 {%- endmacro %}
 
-{% macro snowflake__get_test_dates() -%}
-select
-    cast('2020-11-29' as date) as date_day,
-    cast('2020-11-28' as date) as prior_date_day,
-    cast('2020-11-30' as date) as next_date_day,
-    'Sunday' as day_name,
-    'Sun' as day_name_short,
-    29 as day_of_month,
-    1 as day_of_week,
-    7 as iso_day_of_week,
-    334 as day_of_year,
-    cast('2020-11-29' as date) as week_start_date,
-    cast('2020-12-05' as date) as week_end_date,
-    48 as week_of_year,
-    -- in ISO terms, this is the end of the prior week
-    cast('2020-11-23' as date) as iso_week_start_date,
-    cast('2020-11-29' as date) as iso_week_end_date,
-    48 as iso_week_of_year,
-    'November' as month_name,
-    'Nov' as month_name_short
+{% macro get_test_week_of_year() -%}
+    {{ return(adapter.dispatch('get_test_week_of_year', packages = dbt_date_integration_tests._get_utils_namespaces()) ()) }}
+{%- endmacro %}
 
-    union all
+{% macro default__get_test_week_of_year() -%}
+    {{ log("in default macro", info=True) }}
+    {# weeks_of_year for '2020-11-29' and '2020-12-01', respectively #}
+    {{ return([48,48]) }}
+{%- endmacro %}
 
-select
-    cast('2020-12-01' as date) as date_day,
-    cast('2020-11-30' as date) as prior_date_day,
-    cast('2020-12-02' as date) as next_date_day,
-    'Tuesday' as day_name,
-    'Tue' as day_name_short,
-    1 as day_of_month,
-    3 as day_of_week,
-    2 as iso_day_of_week,
-    336 as day_of_year,
-    cast('2020-11-29' as date) as week_start_date,
-    cast('2020-12-05' as date) as week_end_date,
-    -- Snowflake returns ISO week numbers with the standard config
-    49 as week_of_year,
-
-    cast('2020-11-30' as date) as iso_week_start_date,
-    cast('2020-12-06' as date) as iso_week_end_date,
-    49 as iso_week_of_year,
-    'December' as month_name,
-    'Dec' as month_name_short
+{% macro snowflake__get_test_week_of_year() -%}
+    {# weeks_of_year for '2020-11-29' and '2020-12-01', respectively #}
+    {# Snowflake uses ISO year #}
+    {{ return([48,49]) }}
 {%- endmacro %}

--- a/integration_tests/macros/get_test_dates.sql
+++ b/integration_tests/macros/get_test_dates.sql
@@ -46,7 +46,6 @@ select
 {%- endmacro %}
 
 {% macro default__get_test_week_of_year() -%}
-    {{ log("in default macro", info=True) }}
     {# weeks_of_year for '2020-11-29' and '2020-12-01', respectively #}
     {{ return([48,48]) }}
 {%- endmacro %}


### PR DESCRIPTION
### high-level summary
- refactored `get_test_dates()` in order to:
    - more surgically change behavior, and
    -  keep shimmed macros more in line w/ dbt-date's integration tests as they update.
- deleted `dbt_date_integration_tests`'s `_get_utils_namespaces()` to align with `dbt-utils`'s strategy of joining integration test macros to the dispatch list. (note: this will certainly change with `v0.20.0`, but at least it's a step in the right direction. 

### detail

resolves: #25
given that the only difference in `get_test_dates()` is the `week_of_year` column, this will make it easier to shim.

once this merges, making `get_test_dates()` working for TSQL will be as simple as adding this macro to the `tsql-utils` dbt-date integration tests macros folder (see: https://github.com/dbt-msft/tsql-utils/pull/48)

```
{% macro sqlserver__get_test_week_of_year() -%}
    {{ log("in the right macro!", info=True) }}
    {# who knows what T-SQL uses?! #}
    {# see: https://github.com/calogica/dbt-date/issues/25 #}
    {{ return([49,49]) }}
{%- endmacro %}

{% macro synapse__get_test_week_of_year() -%}
     {{ return(sqlserver__get_test_week_of_year()) }}
{%- endmacro %}
```