### PR TITLE
cast day_of attributes to bigint on Redshift

### DIFF
--- a/macros/calendar_date/day_of_month.sql
+++ b/macros/calendar_date/day_of_month.sql
@@ -1,3 +1,7 @@
 {%- macro day_of_month(date) -%}
-cast({{ dbt_date.date_part('day', date) }} as {{ dbt_utils.type_int() }})
+{{ dbt_date.date_part('day', date) }}
+{%- endmacro %}
+
+{%- macro redshift__day_of_month(date) -%}
+cast({{ dbt_date.date_part('day', date) }} as {{ dbt_utils.type_bigint() }})
 {%- endmacro %}

--- a/macros/calendar_date/day_of_month.sql
+++ b/macros/calendar_date/day_of_month.sql
@@ -1,4 +1,3 @@
 {%- macro day_of_month(date) -%}
-{{ dbt_date.date_part('day', date) }}
+cast({{ dbt_date.date_part('day', date) }} as {{ dbt_utils.type_int() }})
 {%- endmacro %}
-

--- a/macros/calendar_date/day_of_week.sql
+++ b/macros/calendar_date/day_of_week.sql
@@ -10,10 +10,10 @@
     case
         -- Shift start of week from Sunday (0) to Monday (1)
         when {{ dow }} = 0 then 7
-        else cast({{ dow }} as {{ dbt_utils.type_int() }})
+        else {{ dow }}
     end
     {%- else -%}
-    cast({{ dow }} + 1 as {{ dbt_utils.type_int() }})
+    {{ dow }} + 1
     {%- endif -%}
 
 {%- endmacro %}
@@ -62,6 +62,23 @@
         {%- set dow_part = 'dow' -%}
         -- Sunday(1) to Saturday (7)
         cast({{ dbt_date.date_part(dow_part, date) }} + 1 as {{ dbt_utils.type_int() }})
+    {%- endif -%}
+
+{%- endmacro %}
+
+
+{%- macro redshift__day_of_week(date, isoweek) -%}
+
+    {%- set dow = dbt_date.date_part('dayofweek', date) -%}
+
+    {%- if isoweek -%}
+    case
+        -- Shift start of week from Sunday (0) to Monday (1)
+        when {{ dow }} = 0 then 7
+        else cast({{ dow }} as {{ dbt_utils.type_bigint() }})
+    end
+    {%- else -%}
+    cast({{ dow }} + 1 as {{ dbt_utils.type_bigint() }})
     {%- endif -%}
 
 {%- endmacro %}

--- a/macros/calendar_date/day_of_week.sql
+++ b/macros/calendar_date/day_of_week.sql
@@ -10,10 +10,10 @@
     case
         -- Shift start of week from Sunday (0) to Monday (1)
         when {{ dow }} = 0 then 7
-        else {{ dow }}
+        else cast({{ dow }} as {{ dbt_utils.type_int() }})
     end
     {%- else -%}
-    {{ dow }} + 1
+    cast({{ dow }} + 1 as {{ dbt_utils.type_int() }})
     {%- endif -%}
 
 {%- endmacro %}
@@ -25,14 +25,14 @@
         {{ dbt_date.date_part(dow_part, date) }}
     {%- else -%}
         {%- set dow_part = 'dayofweek' -%}
-        case 
+        case
             when {{ dbt_date.date_part(dow_part, date) }} = 7 then 1
             else {{ dbt_date.date_part(dow_part, date) }} + 1
         end
     {%- endif -%}
 
-    
-    
+
+
 {%- endmacro %}
 
 {%- macro bigquery__day_of_week(date, isoweek) -%}

--- a/macros/calendar_date/day_of_year.sql
+++ b/macros/calendar_date/day_of_year.sql
@@ -3,9 +3,13 @@
 {%- endmacro %}
 
 {%- macro default__day_of_year(date) -%}
-    cast({{ dbt_date.date_part('dayofyear', date) }} as {{ dbt_utils.type_int() }})
+    {{ dbt_date.date_part('dayofyear', date) }}
 {%- endmacro %}
 
 {%- macro postgres__day_of_year(date) -%}
-    cast({{ dbt_date.date_part('doy', date) }} as {{ dbt_utils.type_int() }})
+    {{ dbt_date.date_part('doy', date) }}
+{%- endmacro %}
+
+{%- macro redshift__day_of_year(date) -%}
+    cast({{ dbt_date.date_part('dayofyear', date) }} as {{ dbt_utils.type_bigint() }})
 {%- endmacro %}

--- a/macros/calendar_date/day_of_year.sql
+++ b/macros/calendar_date/day_of_year.sql
@@ -3,9 +3,9 @@
 {%- endmacro %}
 
 {%- macro default__day_of_year(date) -%}
-    {{ dbt_date.date_part('dayofyear', date) }}
+    cast({{ dbt_date.date_part('dayofyear', date) }} as {{ dbt_utils.type_int() }})
 {%- endmacro %}
 
 {%- macro postgres__day_of_year(date) -%}
-    {{ dbt_date.date_part('doy', date) }}
+    cast({{ dbt_date.date_part('doy', date) }} as {{ dbt_utils.type_int() }})
 {%- endmacro %}


### PR DESCRIPTION
## Issue
The following fields store double values on Redshift (see: #26 )

- `day_of_week`
- `day_of_month`
- `day_of_year`

## Fix 
Cast to bigint specifically for Redshift

## Tests 
The tests `iso_week_*`, `week_start_date`, `week_end_date`, `week_of_year` are failing when run on Redshift as shown in the attached logs. Noticed another pull request to fix the `iso_week` issue and issue #25; and presume it's the same problem with other tests. However, `day_of_*` tests are passing. So, it seems like the fix hasn't broken anything.

[test-output.log](https://github.com/calogica/dbt-date/files/6566812/test-output.log)