### PR TITLE
Fix ISO week start, end, week of year for Redshift

### DIFF
--- a/macros/calendar_date/iso_week_end.sql
+++ b/macros/calendar_date/iso_week_end.sql
@@ -3,16 +3,11 @@
 {{ adapter.dispatch('iso_week_end', packages = dbt_date._get_utils_namespaces()) (dt) }}
 {%- endmacro -%}
 
-{%- macro _iso_week_end(date, week_type) -%}
+{%- macro _iso_week_end(date) -%}
 {%- set dt = dbt_date.iso_week_start(date) -%}
 {{ dbt_date.n_days_away(6, dt) }}
 {%- endmacro %}
 
 {%- macro default__iso_week_end(date) -%}
-{{ dbt_date._iso_week_end(date, 'isoweek') }}
+{{ dbt_date._iso_week_end(date) }}
 {%- endmacro %}
-
-{%- macro snowflake__iso_week_end(date) -%}
-{{ dbt_date._iso_week_end(date, 'weekiso') }}
-{%- endmacro %}
-

--- a/macros/calendar_date/iso_week_of_year.sql
+++ b/macros/calendar_date/iso_week_of_year.sql
@@ -4,7 +4,7 @@
 {%- endmacro -%}
 
 {%- macro _iso_week_of_year(date, week_type) -%}
-cast({{ dbt_date.date_part(week_type, date) }} as {{ dbt_utils.type_int() }}) 
+cast({{ dbt_date.date_part(week_type, date) }} as {{ dbt_utils.type_int() }})
 {%- endmacro %}
 
 {%- macro default__iso_week_of_year(date) -%}
@@ -18,4 +18,8 @@ cast({{ dbt_date.date_part(week_type, date) }} as {{ dbt_utils.type_int() }})
 {%- macro postgres__iso_week_of_year(date) -%}
 -- postgresql week is isoweek, the first week of a year containing January 4 of that year.
 {{ dbt_date._iso_week_of_year(date, 'week') }}
+{%- endmacro %}
+
+{%- macro redshift__iso_week_of_year(date) -%}
+cast(to_char({{ date }}, 'IW') as {{ dbt_utils.type_int() }})
 {%- endmacro %}

--- a/macros/calendar_date/iso_week_start.sql
+++ b/macros/calendar_date/iso_week_start.sql
@@ -18,3 +18,7 @@ cast({{ dbt_utils.date_trunc(week_type, date) }} as date)
 {%- macro postgres__iso_week_start(date) -%}
 {{ dbt_date._iso_week_start(date, 'week') }}
 {%- endmacro %}
+
+{%- macro redshift__iso_week_start(date) -%}
+{{ dbt_date._iso_week_start(date, 'week') }}
+{%- endmacro %}


### PR DESCRIPTION
Adds alternate way to get ISO week on Redshift via `to_char`.

Also, cleans up calls to `iso_week_start` and `iso_week_end`.