### PR TITLE
Add support for date parts in get_base_dates

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -18,7 +18,3 @@ quoting:
 vars:
     'dbt_date:time_zone': 'America/Los_Angeles'
 
-models:
-    dbt_date:
-        example_models:
-            enabled: false

--- a/integration_tests/models/dates.sql
+++ b/integration_tests/models/dates.sql
@@ -1,0 +1,6 @@
+{{
+    config(
+        materialized = "ephemeral"
+    )
+}}
+{{ dbt_date.get_date_dimension('2015-01-01', '2022-12-31') }}

--- a/integration_tests/models/dim_date.sql
+++ b/integration_tests/models/dim_date.sql
@@ -1,3 +1,8 @@
+{{
+    config(
+        materialized = "table"
+    )
+}}
 with date_dimension as (
     select * from {{ ref('dates') }}
 ),
@@ -6,7 +11,7 @@ fiscal_periods as (
 )
 select
     d.*,
-    f.fiscal_week_of_year, 
+    f.fiscal_week_of_year,
     f.fiscal_week_of_period,
     f.fiscal_period_number,
     f.fiscal_quarter_number,

--- a/integration_tests/models/dim_date_fiscal.sql
+++ b/integration_tests/models/dim_date_fiscal.sql
@@ -1,3 +1,8 @@
+{{
+    config(
+        materialized = "table"
+    )
+}}
 with fp as (
     {{ dbt_date.get_fiscal_periods(ref('dates'), year_end_month=1, week_start_day=1) }}
 )

--- a/integration_tests/models/dim_hour.sql
+++ b/integration_tests/models/dim_hour.sql
@@ -1,0 +1,12 @@
+{{
+    config(
+        materialized = "table"
+    )
+}}
+with periods_hours as (
+    {{ dbt_date.get_base_dates(n_dateparts=24*28, datepart="hour") }}
+)
+select
+    d.*
+from
+    periods_hours d

--- a/integration_tests/models/dim_week.sql
+++ b/integration_tests/models/dim_week.sql
@@ -1,0 +1,12 @@
+{{
+    config(
+        materialized = "table"
+    )
+}}
+with periods_weeks as (
+    {{ dbt_date.get_base_dates(n_dateparts=52, datepart="week") }}
+)
+select
+    d.*
+from
+    periods_weeks d

--- a/macros/get_base_dates.sql
+++ b/macros/get_base_dates.sql
@@ -1,4 +1,4 @@
-{% macro get_base_dates(start_date=None, end_date=None, n_dateparts=None, datepart=None) %}
+{% macro get_base_dates(start_date=None, end_date=None, n_dateparts=None, datepart="day") %}
     {{ adapter.dispatch('get_base_dates', packages = dbt_date._get_utils_namespaces()) (start_date, end_date, n_dateparts, datepart) }}
 {% endmacro %}
 
@@ -16,7 +16,7 @@ with date_spine as
     {% endif %}
 
     {{ dbt_utils.date_spine(
-        datepart="day",
+        datepart=datepart,
         start_date=start_date,
         end_date=end_date,
        )
@@ -24,7 +24,7 @@ with date_spine as
 
 )
 select
-    cast(d.date_day as date) as date_day
+    cast(d.date_{{ datepart }} as {{ dbt_utils.type_timestamp() }}) as date_{{ datepart }}
 from
     date_spine d
 {% endmacro %}
@@ -43,7 +43,7 @@ with date_spine as
     {% endif %}
 
     {{ dbt_utils.date_spine(
-        datepart="day",
+        datepart=datepart,
         start_date=start_date,
         end_date=end_date,
        )
@@ -51,7 +51,7 @@ with date_spine as
 
 )
 select
-    cast(d.date_day as date) as date_day
+    cast(d.date_{{ datepart }} as {{ dbt_utils.type_timestamp() }}) as date_{{ datepart }}
 from
     date_spine d
 {% endmacro %}

--- a/models/example_models/dates.sql
+++ b/models/example_models/dates.sql
@@ -1,7 +1,0 @@
-with date_dimension as (
-    {{ dbt_date.get_date_dimension('2015-01-01', '2022-12-31') }}
-)
-select
-    d.*
-from
-    date_dimension d


### PR DESCRIPTION
The `get_base_dates` never really supported day parts other than day, so this PR attempts to fix that.