### PR TITLE
Make new tests tsql compat

### DIFF
--- a/integration_tests/models/dates.sql
+++ b/integration_tests/models/dates.sql
@@ -1,6 +1,1 @@
-{{
-    config(
-        materialized = "ephemeral"
-    )
-}}
-{{ dbt_date.get_date_dimension('2015-01-01', '2022-12-31') }}
+{{ dbt_date.get_date_dimension('2015-01-01', '2015-01-06') }}

--- a/integration_tests/models/dim_hour.sql
+++ b/integration_tests/models/dim_hour.sql
@@ -3,10 +3,8 @@
         materialized = "table"
     )
 }}
-with periods_hours as (
-    {{ dbt_date.get_base_dates(n_dateparts=24*28, datepart="hour") }}
-)
+
 select
-    d.*
+    *
 from
-    periods_hours d
+   ({{ dbt_date.get_base_dates(n_dateparts=24*28, datepart="hour") }})

--- a/integration_tests/models/dim_week.sql
+++ b/integration_tests/models/dim_week.sql
@@ -3,10 +3,8 @@
         materialized = "table"
     )
 }}
-with periods_weeks as (
-    {{ dbt_date.get_base_dates(n_dateparts=52, datepart="week") }}
-)
+
 select
-    d.*
+    *
 from
-    periods_weeks d
+    ( {{ dbt_date.get_base_dates(n_dateparts=52, datepart="week") }} )

--- a/macros/get_date_dimension.sql
+++ b/macros/get_date_dimension.sql
@@ -3,17 +3,14 @@
 {% endmacro %}
 
 {% macro default__get_date_dimension(start_date, end_date) %}
-with base_dates as (
-    {{ dbt_date.get_base_dates(start_date, end_date) }}
-),
-dates_with_prior_year_dates as (
+with dates_with_prior_year_dates as (
 
     select
         cast(d.date_day as date) as date_day,
         cast({{ dbt_utils.dateadd('year', -1 , 'd.date_day') }} as date) as prior_year_date_day,
         cast({{ dbt_utils.dateadd('day', -364 , 'd.date_day') }} as date) as prior_year_over_year_date_day
     from
-    	base_dates d
+    	( {{ dbt_date.get_base_dates(start_date, end_date) }} ) d
 
 )
 select


### PR DESCRIPTION
necessary updates per #30. It seems there's some fast-moving goal posts for getting dbt-date integration tests passing for the dbt-msft adapters.

I'm struggling to work with the new nested CTEs and ephemeral model that was introduced in the PR.

Double struggle because I thought that [this change](https://github.com/dbt-msft/tsql-utils/blob/7123c80f24ed7844537800af07a90247e319055a/integration_tests/dbt_utils/dbt_project.yml#L54-L59) would at least disable these new models from being run and tested.

```yml
models:
  dbt_date_integration_tests:
    dates: &disabled
        +enabled: false
    dim_week: *disabled
    dim_hour: *disabled
```