### PR TITLE
Update for dbt 0.20 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# dbt-date v0.3.1
+
+*Patch release*
+
+## Fixes
+
+* Fixed a bug in `snowflake__from_unixtimestamp` that prevented the core functionaility from being called ([#38](https://github.com/calogica/dbt-date/pull/38) by @swanderz)
+
+## Under the hood
+
+* Simplified `join` syntax ([#36](https://github.com/calogica/dbt-date/pull/36))
+
 # dbt-date v0.3.0
 
 ## Breaking Changes

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -8,7 +8,7 @@ clean-targets: ["target", "dbt_modules"]
 macro-paths: ["macros"]
 log-path: "logs"
 
-require-dbt-version: [">=0.18.0", "<0.20.0"]
+require-dbt-version: [">=0.20.0", "<0.21.0"]
 profile: integration_tests
 
 quoting:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -19,6 +19,10 @@ clean-targets:
 
 require-dbt-version: ">=0.18.1"
 
+dispatch:
+  - macro_namespace: dbt_date
+    search_order: ['dbt_date_integration_tests', 'dbt_date']  # enable override
+
 vars:
     dbt_date_dispatch_list: ['dbt_date_integration_tests']
     "dbt_date:time_zone": "America/Los_Angeles"

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -17,8 +17,6 @@ clean-targets:
     - "target"
     - "dbt_modules"
 
-require-dbt-version: ">=0.18.1"
-
 dispatch:
   - macro_namespace: dbt_date
     search_order: ['dbt_date_integration_tests', 'dbt_date']  # enable override

--- a/integration_tests/macros/get_test_dates.sql
+++ b/integration_tests/macros/get_test_dates.sql
@@ -17,9 +17,12 @@ select
     cast('2020-11-29' as date) as iso_week_end_date,
     48 as iso_week_of_year,
     'November' as month_name,
-    'Nov' as month_name_short
+    'Nov' as month_name_short,
+    1623076520 as unix_epoch,
+    cast('{{ get_test_timestamps()[0] }}' as {{ dbt_utils.type_timestamp() }}) as time_stamp,
+    cast('{{ get_test_timestamps()[1] }}' as {{ dbt_utils.type_timestamp() }}) as time_stamp_utc
 
-    union all
+union all
 
 select
     cast('2020-12-01' as date) as date_day,
@@ -38,11 +41,16 @@ select
     cast('2020-12-06' as date) as iso_week_end_date,
     49 as iso_week_of_year,
     'December' as month_name,
-    'Dec' as month_name_short
+    'Dec' as month_name_short,
+    {# 1623051320 as unix_epoch, #}
+    1623076520 as unix_epoch,
+    cast('{{ get_test_timestamps()[0] }}' as {{ dbt_utils.type_timestamp() }}) as time_stamp,
+    cast('{{ get_test_timestamps()[1] }}' as {{ dbt_utils.type_timestamp() }}) as time_stamp_utc
+
 {%- endmacro %}
 
 {% macro get_test_week_of_year() -%}
-    {{ return(adapter.dispatch('get_test_week_of_year', packages = dbt_date._get_utils_namespaces()) ()) }}
+    {{ return(adapter.dispatch('get_test_week_of_year', 'dbt_date_integration_tests') ()) }}
 {%- endmacro %}
 
 {% macro default__get_test_week_of_year() -%}
@@ -55,3 +63,27 @@ select
     {# Snowflake uses ISO year #}
     {{ return([48,49]) }}
 {%- endmacro %}
+
+
+
+{% macro get_test_timestamps() -%}
+    {{ return(adapter.dispatch('get_test_timestamps', 'dbt_date_integration_tests') ()) }}
+{%- endmacro %}
+
+{% macro default__get_test_timestamps() -%}
+    {{ return(['2021-06-07 07:35:20.000000 America/Los_Angeles',
+                '2021-06-07 14:35:20.000000 UTC']) }}
+{%- endmacro %}
+
+{% macro bigquery__get_test_timestamps() -%}
+    {{ return(['2021-06-07 07:35:20.000000',
+                '2021-06-07 14:35:20.000000']) }}
+{%- endmacro %}
+
+{% macro snowflake__get_test_timestamps() -%}
+    {{ return(['2021-06-07 07:35:20.000000 -0700',
+                '2021-06-07 14:35:20.000000 -0000']) }}
+{%- endmacro %}
+
+
+

--- a/integration_tests/macros/get_test_dates.sql
+++ b/integration_tests/macros/get_test_dates.sql
@@ -50,7 +50,7 @@ select
 {%- endmacro %}
 
 {% macro get_test_week_of_year() -%}
-    {{ return(adapter.dispatch('get_test_week_of_year', packages = dbt_date._get_utils_namespaces()) ()) }}
+    {{ return(adapter.dispatch('get_test_week_of_year', 'dbt_date_integration_tests') ()) }}
 {%- endmacro %}
 
 {% macro default__get_test_week_of_year() -%}
@@ -67,7 +67,7 @@ select
 
 
 {% macro get_test_timestamps() -%}
-    {{ return(adapter.dispatch('get_test_timestamps', packages = dbt_date._get_utils_namespaces()) ()) }}
+    {{ return(adapter.dispatch('get_test_timestamps', 'dbt_date_integration_tests') ()) }}
 {%- endmacro %}
 
 {% macro default__get_test_timestamps() -%}

--- a/integration_tests/macros/get_test_dates.sql
+++ b/integration_tests/macros/get_test_dates.sql
@@ -17,9 +17,12 @@ select
     cast('2020-11-29' as date) as iso_week_end_date,
     48 as iso_week_of_year,
     'November' as month_name,
-    'Nov' as month_name_short
+    'Nov' as month_name_short,
+    1623076520 as unix_epoch,
+    cast('{{ get_test_timestamps()[0] }}' as {{ dbt_utils.type_timestamp() }}) as time_stamp,
+    cast('{{ get_test_timestamps()[1] }}' as {{ dbt_utils.type_timestamp() }}) as time_stamp_utc
 
-    union all
+union all
 
 select
     cast('2020-12-01' as date) as date_day,
@@ -38,7 +41,12 @@ select
     cast('2020-12-06' as date) as iso_week_end_date,
     49 as iso_week_of_year,
     'December' as month_name,
-    'Dec' as month_name_short
+    'Dec' as month_name_short,
+    {# 1623051320 as unix_epoch, #}
+    1623076520 as unix_epoch,
+    cast('{{ get_test_timestamps()[0] }}' as {{ dbt_utils.type_timestamp() }}) as time_stamp,
+    cast('{{ get_test_timestamps()[1] }}' as {{ dbt_utils.type_timestamp() }}) as time_stamp_utc
+
 {%- endmacro %}
 
 {% macro get_test_week_of_year() -%}
@@ -55,3 +63,27 @@ select
     {# Snowflake uses ISO year #}
     {{ return([48,49]) }}
 {%- endmacro %}
+
+
+
+{% macro get_test_timestamps() -%}
+    {{ return(adapter.dispatch('get_test_timestamps', packages = dbt_date._get_utils_namespaces()) ()) }}
+{%- endmacro %}
+
+{% macro default__get_test_timestamps() -%}
+    {{ return(['2021-06-07 07:35:20.000000 America/Los_Angeles',
+                '2021-06-07 14:35:20.000000 UTC']) }}
+{%- endmacro %}
+
+{% macro bigquery__get_test_timestamps() -%}
+    {{ return(['2021-06-07 07:35:20.000000',
+                '2021-06-07 14:35:20.000000']) }}
+{%- endmacro %}
+
+{% macro snowflake__get_test_timestamps() -%}
+    {{ return(['2021-06-07 07:35:20.000000 -0700',
+                '2021-06-07 14:35:20.000000 -0000']) }}
+{%- endmacro %}
+
+
+

--- a/integration_tests/models/test_dates.sql
+++ b/integration_tests/models/test_dates.sql
@@ -1,1 +1,6 @@
+{{
+    config(
+        materialized = 'table'
+    )
+}}
 {{ dbt_date_integration_tests.get_test_dates() }}

--- a/integration_tests/models/test_dates.yml
+++ b/integration_tests/models/test_dates.yml
@@ -7,30 +7,36 @@ models:
         - dbt_utils.expression_is_true:
             expression: "next_date_day = {{ dbt_date.tomorrow('date_day') }}"
         - dbt_utils.expression_is_true:
-            expression: "day_name = {{ dbt_date.day_name('date_day', short=False) }}" 
+            expression: "day_name = {{ dbt_date.day_name('date_day', short=False) }}"
         - dbt_utils.expression_is_true:
-            expression: "day_name_short = {{ dbt_date.day_name('date_day', short=True) }}" 
+            expression: "day_name_short = {{ dbt_date.day_name('date_day', short=True) }}"
         - dbt_utils.expression_is_true:
-            expression: "day_of_month = {{ dbt_date.day_of_month('date_day') }}" 
+            expression: "day_of_month = {{ dbt_date.day_of_month('date_day') }}"
         - dbt_utils.expression_is_true:
-            expression: "day_of_week = {{ dbt_date.day_of_week('date_day', isoweek=False) }}" 
+            expression: "day_of_week = {{ dbt_date.day_of_week('date_day', isoweek=False) }}"
         - dbt_utils.expression_is_true:
-            expression: "iso_day_of_week = {{ dbt_date.day_of_week('date_day', isoweek=True) }}" 
+            expression: "iso_day_of_week = {{ dbt_date.day_of_week('date_day', isoweek=True) }}"
         - dbt_utils.expression_is_true:
-            expression: "day_of_year = {{ dbt_date.day_of_year('date_day') }}" 
+            expression: "day_of_year = {{ dbt_date.day_of_year('date_day') }}"
 
         - dbt_utils.expression_is_true:
-            expression: "week_start_date = {{ dbt_date.week_start('date_day') }}" 
+            expression: "week_start_date = {{ dbt_date.week_start('date_day') }}"
         - dbt_utils.expression_is_true:
-            expression: "week_end_date = {{ dbt_date.week_end('date_day') }}" 
+            expression: "week_end_date = {{ dbt_date.week_end('date_day') }}"
         - dbt_utils.expression_is_true:
-            expression: "week_of_year = {{ dbt_date.week_of_year('date_day') }}" 
+            expression: "week_of_year = {{ dbt_date.week_of_year('date_day') }}"
         - dbt_utils.expression_is_true:
-            expression: "iso_week_start_date = {{ dbt_date.iso_week_start('date_day') }}" 
+            expression: "iso_week_start_date = {{ dbt_date.iso_week_start('date_day') }}"
         - dbt_utils.expression_is_true:
-            expression: "iso_week_end_date = {{ dbt_date.iso_week_end('date_day') }}" 
+            expression: "iso_week_end_date = {{ dbt_date.iso_week_end('date_day') }}"
         - dbt_utils.expression_is_true:
-            expression: "iso_week_of_year = {{ dbt_date.iso_week_of_year('date_day') }}" 
+            expression: "iso_week_of_year = {{ dbt_date.iso_week_of_year('date_day') }}"
+        - dbt_utils.expression_is_true:
+            expression: "time_stamp_utc = {{ dbt_date.from_unixtimestamp('unix_epoch') }}"
+        - dbt_utils.expression_is_true:
+            expression: "unix_epoch = {{ dbt_date.to_unixtimestamp('time_stamp_utc') }}"
+        - dbt_utils.expression_is_true:
+            expression: "time_stamp = {{ dbt_date.convert_timezone('time_stamp_utc') }}"
 
     columns:
       - name: date_day

--- a/macros/_get_utils_namespaces.sql
+++ b/macros/_get_utils_namespaces.sql
@@ -1,4 +1,0 @@
-{% macro _get_utils_namespaces() %}
-  {% set override_namespaces = var('dbt_date_dispatch_list', []) %}
-  {% do return(override_namespaces + ['dbt_date']) %}
-{% endmacro %}

--- a/macros/calendar_date/convert_timezone.sql
+++ b/macros/calendar_date/convert_timezone.sql
@@ -1,7 +1,7 @@
 {%- macro convert_timezone(column, target_tz=None, source_tz=None) -%}
 {%- set source_tz = "UTC" if not source_tz else source_tz -%}
 {%- set target_tz = var("dbt_date:time_zone") if not target_tz else target_tz -%}
-{{ adapter.dispatch('convert_timezone', packages = dbt_date._get_utils_namespaces()) (column, target_tz, source_tz) }}
+{{ adapter.dispatch('convert_timezone', 'dbt_date') (column, target_tz, source_tz) }}
 {%- endmacro -%}
 
 {% macro default__convert_timezone(column, target_tz, source_tz) -%}
@@ -24,5 +24,9 @@ from_utc_timestamp(
 {%- endmacro -%}
 
 {% macro postgres__convert_timezone(column, target_tz, source_tz) -%}
+{%- if source_tz -%}
 cast({{ column }} at time zone '{{ source_tz }}' at time zone '{{ target_tz }}' as {{ dbt_utils.type_timestamp() }})
+{%- else -%}
+cast({{ column }} at time zone '{{ target_tz }}' as {{ dbt_utils.type_timestamp() }})
+{%- endif -%}
 {%- endmacro -%}

--- a/macros/calendar_date/date_part.sql
+++ b/macros/calendar_date/date_part.sql
@@ -1,5 +1,5 @@
 {% macro date_part(datepart, date) -%}
-    {{ adapter.dispatch('date_part', packages = dbt_date._get_utils_namespaces()) (datepart, date) }}
+    {{ adapter.dispatch('date_part', 'dbt_date') (datepart, date) }}
 {%- endmacro %}
 
 {% macro default__date_part(datepart, date) -%}

--- a/macros/calendar_date/day_name.sql
+++ b/macros/calendar_date/day_name.sql
@@ -1,5 +1,5 @@
 {%- macro day_name(date, short=True) -%}
-    {{ adapter.dispatch('day_name', packages = dbt_date._get_utils_namespaces()) (date, short) }}
+    {{ adapter.dispatch('day_name', 'dbt_date') (date, short) }}
 {%- endmacro %}
 
 {%- macro default__day_name(date, short) -%}
@@ -22,7 +22,7 @@
         when 'Sun' then 'Sunday'
     end
     {%- endif -%}
-    
+
 {%- endmacro %}
 
 {%- macro bigquery__day_name(date, short) -%}

--- a/macros/calendar_date/day_of_week.sql
+++ b/macros/calendar_date/day_of_week.sql
@@ -1,5 +1,5 @@
 {%- macro day_of_week(date, isoweek=true) -%}
-{{ adapter.dispatch('day_of_week', packages = dbt_date._get_utils_namespaces()) (date, isoweek) }}
+{{ adapter.dispatch('day_of_week', 'dbt_date') (date, isoweek) }}
 {%- endmacro %}
 
 {%- macro default__day_of_week(date, isoweek) -%}

--- a/macros/calendar_date/day_of_year.sql
+++ b/macros/calendar_date/day_of_year.sql
@@ -1,5 +1,5 @@
 {%- macro day_of_year(date) -%}
-{{ adapter.dispatch('day_of_year', packages = dbt_date._get_utils_namespaces()) (date) }}
+{{ adapter.dispatch('day_of_year', 'dbt_date') (date) }}
 {%- endmacro %}
 
 {%- macro default__day_of_year(date) -%}

--- a/macros/calendar_date/from_unixtimestamp.sql
+++ b/macros/calendar_date/from_unixtimestamp.sql
@@ -2,8 +2,28 @@
     {{ adapter.dispatch('from_unixtimestamp', packages = dbt_date._get_utils_namespaces()) (epochs, format) }}
 {%- endmacro %}
 
+{%- macro default__from_unixtimestamp(epochs, format="seconds") -%}
+    {%- if format != "seconds" -%}
+    {{ exceptions.raise_compiler_error(
+        "value " ~ format ~ " for `format` for from_unixtimestamp is not supported."
+        )
+    }}
+    {% endif -%}
+    to_timestamp({{ epochs }})
+{%- endmacro %}
+
+{%- macro postgres__from_unixtimestamp(epochs, format="seconds") -%}
+    {%- if format != "seconds" -%}
+    {{ exceptions.raise_compiler_error(
+        "value " ~ format ~ " for `format` for from_unixtimestamp is not supported."
+        )
+    }}
+    {% endif -%}
+    cast(to_timestamp({{ epochs }}) at time zone 'UTC' as timestamp)
+{%- endmacro %}
+
 {%- macro snowflake__from_unixtimestamp(epochs, format) -%}
-    
+
     {%- if format == "seconds" -%}
     {%- set scale = 0 -%}
     {%- elif format == "milliseconds" -%}
@@ -13,10 +33,10 @@
     {%- else -%}
     {{ exceptions.raise_compiler_error(
         "value " ~ format ~ " for `format` for from_unixtimestamp is not supported."
-        ) 
+        )
     }}
     {% endif -%}
-    
+
     to_timestamp_ntz({{ epochs }}, {{ scale }})
 
 {%- endmacro %}
@@ -31,7 +51,7 @@
     {%- else -%}
     {{ exceptions.raise_compiler_error(
         "value " ~ format ~ " for `format` for from_unixtimestamp is not supported."
-        ) 
+        )
     }}
     {% endif -%}
 {%- endmacro %}

--- a/macros/calendar_date/from_unixtimestamp.sql
+++ b/macros/calendar_date/from_unixtimestamp.sql
@@ -15,8 +15,9 @@
         "value " ~ format ~ " for `format` for from_unixtimestamp is not supported."
         ) 
     }}
-    to_timestamp_ntz({{ epochs }}, {{ scale }})
     {% endif -%}
+    
+    to_timestamp_ntz({{ epochs }}, {{ scale }})
 
 {%- endmacro %}
 

--- a/macros/calendar_date/from_unixtimestamp.sql
+++ b/macros/calendar_date/from_unixtimestamp.sql
@@ -22,17 +22,6 @@
     cast(to_timestamp({{ epochs }}) at time zone 'UTC' as timestamp)
 {%- endmacro %}
 
-{%- macro postgres__from_unixtimestamp(epochs, format="seconds") -%}
-    {%- if format != "seconds" -%}
-    {{ exceptions.raise_compiler_error(
-        "value " ~ format ~ " for `format` for from_unixtimestamp is not supported."
-        )
-    }}
-    {% endif -%}
-    cast(to_timestamp({{ epochs }}) at time zone 'UTC' as timestamp)
-{%- endmacro %}
-
-
 {%- macro snowflake__from_unixtimestamp(epochs, format) -%}
     {%- if format == "seconds" -%}
     {%- set scale = 0 -%}

--- a/macros/calendar_date/from_unixtimestamp.sql
+++ b/macros/calendar_date/from_unixtimestamp.sql
@@ -1,9 +1,18 @@
 {%- macro from_unixtimestamp(epochs, format="seconds") -%}
-    {{ adapter.dispatch('from_unixtimestamp', packages = dbt_date._get_utils_namespaces()) (epochs, format) }}
+    {{ adapter.dispatch('from_unixtimestamp', 'dbt_date') (epochs, format) }}
+{%- endmacro %}
+
+{%- macro default__from_unixtimestamp(epochs, format="seconds") -%}
+    {%- if format != "seconds" -%}
+    {{ exceptions.raise_compiler_error(
+        "value " ~ format ~ " for `format` for from_unixtimestamp is not supported."
+        )
+    }}
+    {% endif -%}
+    to_timestamp({{ epochs }})
 {%- endmacro %}
 
 {%- macro snowflake__from_unixtimestamp(epochs, format) -%}
-    
     {%- if format == "seconds" -%}
     {%- set scale = 0 -%}
     {%- elif format == "milliseconds" -%}
@@ -13,10 +22,10 @@
     {%- else -%}
     {{ exceptions.raise_compiler_error(
         "value " ~ format ~ " for `format` for from_unixtimestamp is not supported."
-        ) 
+        )
     }}
-    to_timestamp_ntz({{ epochs }}, {{ scale }})
     {% endif -%}
+    to_timestamp_ntz({{ epochs }}, {{ scale }})
 
 {%- endmacro %}
 
@@ -30,7 +39,7 @@
     {%- else -%}
     {{ exceptions.raise_compiler_error(
         "value " ~ format ~ " for `format` for from_unixtimestamp is not supported."
-        ) 
+        )
     }}
     {% endif -%}
 {%- endmacro %}

--- a/macros/calendar_date/from_unixtimestamp.sql
+++ b/macros/calendar_date/from_unixtimestamp.sql
@@ -12,6 +12,17 @@
     to_timestamp({{ epochs }})
 {%- endmacro %}
 
+{%- macro postgres__from_unixtimestamp(epochs, format="seconds") -%}
+    {%- if format != "seconds" -%}
+    {{ exceptions.raise_compiler_error(
+        "value " ~ format ~ " for `format` for from_unixtimestamp is not supported."
+        )
+    }}
+    {% endif -%}
+    cast(to_timestamp({{ epochs }}) at time zone 'UTC' as timestamp)
+{%- endmacro %}
+
+
 {%- macro snowflake__from_unixtimestamp(epochs, format) -%}
     {%- if format == "seconds" -%}
     {%- set scale = 0 -%}

--- a/macros/calendar_date/from_unixtimestamp.sql
+++ b/macros/calendar_date/from_unixtimestamp.sql
@@ -1,5 +1,5 @@
 {%- macro from_unixtimestamp(epochs, format="seconds") -%}
-    {{ adapter.dispatch('from_unixtimestamp', packages = dbt_date._get_utils_namespaces()) (epochs, format) }}
+    {{ adapter.dispatch('from_unixtimestamp', 'dbt_date') (epochs, format) }}
 {%- endmacro %}
 
 {%- macro default__from_unixtimestamp(epochs, format="seconds") -%}
@@ -23,7 +23,6 @@
 {%- endmacro %}
 
 {%- macro snowflake__from_unixtimestamp(epochs, format) -%}
-
     {%- if format == "seconds" -%}
     {%- set scale = 0 -%}
     {%- elif format == "milliseconds" -%}
@@ -36,6 +35,7 @@
         )
     }}
     {% endif -%}
+    to_timestamp_ntz({{ epochs }}, {{ scale }})
 
     to_timestamp_ntz({{ epochs }}, {{ scale }})
 

--- a/macros/calendar_date/iso_week_end.sql
+++ b/macros/calendar_date/iso_week_end.sql
@@ -1,6 +1,6 @@
 {%- macro iso_week_end(date=None, tz=None) -%}
 {%-set dt = date if date else dbt_date.today(tz) -%}
-{{ adapter.dispatch('iso_week_end', packages = dbt_date._get_utils_namespaces()) (dt) }}
+{{ adapter.dispatch('iso_week_end', 'dbt_date') (dt) }}
 {%- endmacro -%}
 
 {%- macro _iso_week_end(date, week_type) -%}

--- a/macros/calendar_date/iso_week_of_year.sql
+++ b/macros/calendar_date/iso_week_of_year.sql
@@ -1,10 +1,10 @@
 {%- macro iso_week_of_year(date=None, tz=None) -%}
 {%-set dt = date if date else dbt_date.today(tz) -%}
-{{ adapter.dispatch('iso_week_of_year', packages = dbt_date._get_utils_namespaces()) (dt) }}
+{{ adapter.dispatch('iso_week_of_year', 'dbt_date') (dt) }}
 {%- endmacro -%}
 
 {%- macro _iso_week_of_year(date, week_type) -%}
-cast({{ dbt_date.date_part(week_type, date) }} as {{ dbt_utils.type_int() }}) 
+cast({{ dbt_date.date_part(week_type, date) }} as {{ dbt_utils.type_int() }})
 {%- endmacro %}
 
 {%- macro default__iso_week_of_year(date) -%}

--- a/macros/calendar_date/iso_week_start.sql
+++ b/macros/calendar_date/iso_week_start.sql
@@ -1,6 +1,6 @@
 {%- macro iso_week_start(date=None, tz=None) -%}
 {%-set dt = date if date else dbt_date.today(tz) -%}
-{{ adapter.dispatch('iso_week_start', packages = dbt_date._get_utils_namespaces()) (dt) }}
+{{ adapter.dispatch('iso_week_start', 'dbt_date') (dt) }}
 {%- endmacro -%}
 
 {%- macro _iso_week_start(date, week_type) -%}

--- a/macros/calendar_date/month_name.sql
+++ b/macros/calendar_date/month_name.sql
@@ -1,5 +1,5 @@
 {%- macro month_name(date, short=True) -%}
-    {{ adapter.dispatch('month_name', packages = dbt_date._get_utils_namespaces()) (date, short) }}
+    {{ adapter.dispatch('month_name', 'dbt_date') (date, short) }}
 {%- endmacro %}
 
 {%- macro default__month_name(date, short) -%}

--- a/macros/calendar_date/to_unixtimestamp.sql
+++ b/macros/calendar_date/to_unixtimestamp.sql
@@ -3,6 +3,10 @@
 {%- endmacro %}
 
 {%- macro default__to_unixtimestamp(timestamp) -%}
+    {{ dbt_date.date_part('epoch', timestamp) }}
+{%- endmacro %}
+
+{%- macro snowflake__to_unixtimestamp(timestamp) -%}
     {{ dbt_date.date_part('epoch_seconds', timestamp) }}
 {%- endmacro %}
 

--- a/macros/calendar_date/to_unixtimestamp.sql
+++ b/macros/calendar_date/to_unixtimestamp.sql
@@ -1,5 +1,5 @@
 {%- macro to_unixtimestamp(timestamp) -%}
-    {{ adapter.dispatch('to_unixtimestamp', packages = dbt_date._get_utils_namespaces()) (timestamp) }}
+    {{ adapter.dispatch('to_unixtimestamp', 'dbt_date') (timestamp) }}
 {%- endmacro %}
 
 {%- macro default__to_unixtimestamp(timestamp) -%}

--- a/macros/calendar_date/to_unixtimestamp.sql
+++ b/macros/calendar_date/to_unixtimestamp.sql
@@ -1,8 +1,12 @@
 {%- macro to_unixtimestamp(timestamp) -%}
-    {{ adapter.dispatch('to_unixtimestamp', packages = dbt_date._get_utils_namespaces()) (timestamp) }}
+    {{ adapter.dispatch('to_unixtimestamp', 'dbt_date') (timestamp) }}
 {%- endmacro %}
 
 {%- macro default__to_unixtimestamp(timestamp) -%}
+    {{ dbt_date.date_part('epoch', timestamp) }}
+{%- endmacro %}
+
+{%- macro snowflake__to_unixtimestamp(timestamp) -%}
     {{ dbt_date.date_part('epoch_seconds', timestamp) }}
 {%- endmacro %}
 

--- a/macros/calendar_date/week_end.sql
+++ b/macros/calendar_date/week_end.sql
@@ -1,6 +1,6 @@
 {%- macro week_end(date=None, tz=None) -%}
 {%-set dt = date if date else dbt_date.today(tz) -%}
-{{ adapter.dispatch('week_end', packages = dbt_date._get_utils_namespaces()) (dt) }}
+{{ adapter.dispatch('week_end', 'dbt_date') (dt) }}
 {%- endmacro -%}
 
 {%- macro default__week_end(date) -%}

--- a/macros/calendar_date/week_of_year.sql
+++ b/macros/calendar_date/week_of_year.sql
@@ -1,6 +1,6 @@
 {%- macro week_of_year(date=None, tz=None) -%}
 {%-set dt = date if date else dbt_date.today(tz) -%}
-{{ adapter.dispatch('week_of_year', packages = dbt_date._get_utils_namespaces()) (dt) }}
+{{ adapter.dispatch('week_of_year', 'dbt_date') (dt) }}
 {%- endmacro -%}
 
 {%- macro default__week_of_year(date) -%}

--- a/macros/calendar_date/week_start.sql
+++ b/macros/calendar_date/week_start.sql
@@ -1,6 +1,6 @@
 {%- macro week_start(date=None, tz=None) -%}
 {%-set dt = date if date else dbt_date.today(tz) -%}
-{{ adapter.dispatch('week_start', packages = dbt_date._get_utils_namespaces()) (dt) }}
+{{ adapter.dispatch('week_start', 'dbt_date') (dt) }}
 {%- endmacro -%}
 
 {%- macro default__week_start(date) -%}
@@ -8,7 +8,7 @@ cast({{ dbt_utils.date_trunc('week', date) }} as date)
 {%- endmacro %}
 
 {%- macro snowflake__week_start(date) -%}
-case 
+case
     when {{ dbt_date.day_of_week(dbt_utils.date_trunc('week', date), isoweek=False) }} = 1
     then {{ dbt_date.n_days_ago(
             dbt_date.day_of_week(date, isoweek=False) ~ " - 1",

--- a/macros/fiscal_date/get_fiscal_year_dates.sql
+++ b/macros/fiscal_date/get_fiscal_year_dates.sql
@@ -1,9 +1,9 @@
 {% macro get_fiscal_year_dates(dates, year_end_month=12, week_start_day=1, shift_year=1) %}
-{{ adapter.dispatch('get_fiscal_year_dates', packages = dbt_date._get_utils_namespaces()) (dates, year_end_month, week_start_day, shift_year) }}
+{{ adapter.dispatch('get_fiscal_year_dates', 'dbt_date') (dates, year_end_month, week_start_day, shift_year) }}
 {% endmacro %}
 
 {% macro default__get_fiscal_year_dates(dates, year_end_month, week_start_day, shift_year) %}
--- this gets all the dates within a fiscal year 
+-- this gets all the dates within a fiscal year
 -- determined by the given year-end-month
 -- ending on the saturday closest to that month's end date
 with date_dimension as (
@@ -30,7 +30,7 @@ weeks as (
         cast({{ dbt_utils.dateadd('day', 6, 'd.date_day') }} as date) as week_end_date
     from
         date_dimension d
-    where 
+    where
         d.day_of_week = {{ week_start_day }}
 
 ),
@@ -44,7 +44,7 @@ year_week_ends as (
         weeks d
     where
         d.month_of_year = {{ year_end_month }}
-    group by 
+    group by
         1,2
 
 ),
@@ -71,13 +71,13 @@ fiscal_year_range as (
     select
         w.fiscal_year_number,
         cast(
-            {{ dbt_utils.dateadd('day', 1, 
+            {{ dbt_utils.dateadd('day', 1,
             'lag(w.week_end_date) over(order by w.week_end_date)') }}
             as date) as fiscal_year_start_date,
         w.week_end_date as fiscal_year_end_date
     from
         weeks_at_month_end w
-    where 
+    where
         w.closest_to_month_end = 1
 
 ),
@@ -91,11 +91,11 @@ fiscal_year_dates as (
         w.week_start_date,
         w.week_end_date,
         -- we reset the weeks of the year starting with the merch year start date
-        dense_rank() 
+        dense_rank()
             over(
-                partition by m.fiscal_year_number 
+                partition by m.fiscal_year_number
                 order by w.week_start_date
-                ) as fiscal_week_of_year 
+                ) as fiscal_week_of_year
     from
         date_dimension d
         join

--- a/macros/get_base_dates.sql
+++ b/macros/get_base_dates.sql
@@ -1,5 +1,5 @@
 {% macro get_base_dates(start_date=None, end_date=None, n_dateparts=None, datepart="day") %}
-    {{ adapter.dispatch('get_base_dates', packages = dbt_date._get_utils_namespaces()) (start_date, end_date, n_dateparts, datepart) }}
+    {{ adapter.dispatch('get_base_dates', 'dbt_date') (start_date, end_date, n_dateparts, datepart) }}
 {% endmacro %}
 
 {% macro default__get_base_dates(start_date, end_date, n_dateparts, datepart) %}

--- a/macros/get_date_dimension.sql
+++ b/macros/get_date_dimension.sql
@@ -1,5 +1,5 @@
 {% macro get_date_dimension(start_date, end_date) %}
-    {{ adapter.dispatch('get_date_dimension', packages = dbt_date._get_utils_namespaces()) (start_date, end_date) }}
+    {{ adapter.dispatch('get_date_dimension', 'dbt_date') (start_date, end_date) }}
 {% endmacro %}
 
 {% macro default__get_date_dimension(start_date, end_date) %}

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
-  - package: fishtown-analytics/dbt_utils
+  - package: dbt-labs/dbt_utils
     version: [">=0.7.0", "<0.8.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: fishtown-analytics/dbt_utils
-    version: [">=0.6.0", "<0.7.0"]
+    version: [">=0.7.0", "<0.8.0"]


### PR DESCRIPTION
- Requires dbt 0.20.0+
- Requires dbt-utils 0.7.0+
- Updates calls to `adapter.dispatch` (see #34)
- Adds tests for timestamp and timezone macros (previously untested, new dbt version highlighted that!?) 