### PR TITLE
Patch release to support dbt 0.1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 target/
 dbt_modules/
+dbt_packages/
 logs/
 .python-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# dbt-date v0.4.2
+## Under the hood
+* Support for dbt 1.x!
+
 # dbt-date v0.4.1
 
 ## Under the hood

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dbt-date v0.4.2
 ## Under the hood
-* Support for dbt 1.x!
+* Patch: adds support for dbt 1.x
 
 # dbt-date v0.4.1
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,14 +1,14 @@
 name: 'dbt_date'
-version: '0.2'
+version: '0.4'
 
 config-version: 2
 
 target-path: "target"
-clean-targets: ["target", "dbt_modules"]
+clean-targets: ["target", "dbt_modules", "dbt_packages"]
 macro-paths: ["macros"]
 log-path: "logs"
 
-require-dbt-version: [">=0.20.0", "<0.22.0"]
+require-dbt-version: [">=0.20.0", "<1.1.0"]
 profile: integration_tests
 
 quoting:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -3,8 +3,6 @@ version: "1.0"
 
 profile: "integration_tests"
 
-# require-dbt-version: inherit this from dbt-utils
-
 config-version: 2
 
 source-paths: ["models"]
@@ -13,9 +11,7 @@ data-paths: ["data"]
 macro-paths: ["macros"]
 
 target-path: "target"
-clean-targets:
-    - "target"
-    - "dbt_modules"
+clean-targets: ["target", "dbt_modules", "dbt_packages"]
 
 dispatch:
   - macro_namespace: dbt_date


### PR DESCRIPTION
This is a backwards compatible patch release that updates following files to support dbt 0.1.x

- .gitignore
- dbt_project.yml
- integration_tests/dbt_project.yml

This release will work with versions of dbt-utils < 0.8.0.

cc: @joellabes