### PR TITLE
Fix timezone conversion macro on redshift

### DIFF
--- a/macros/calendar_date/convert_timezone.sql
+++ b/macros/calendar_date/convert_timezone.sql
@@ -30,3 +30,7 @@ cast({{ column }} at time zone '{{ source_tz }}' at time zone '{{ target_tz }}' 
 cast({{ column }} at time zone '{{ target_tz }}' as {{ dbt_utils.type_timestamp() }})
 {%- endif -%}
 {%- endmacro -%}
+
+{%- macro redshift__convert_timezone(column, target_tz, source_tz) -%}
+{{ return(default__convert_timezone(column, target_tz, source_tz) }}
+{%- endmacro -%}


### PR DESCRIPTION
Hi there! First of all, thank you for building/maintaining this package, I am using it and it rocks. 

When calling a calendar date macro (in my case `dbt_date.today()` on redshift with dbt 1.0.0, I received the following error:
```
18:26:50  Encountered an error:
Runtime Error
  Database Error in model util__dates (models/layer_1_cleaned/utils/util__dates.sql)
    syntax error at or near "UTC"
    LINE 18:  at time zone 'UTC' at time zone 'Etc/UTC' as 
```

I looked into it and basically it seems that the default implementation you had for the timezone conversion [is the supported way in redshift](https://docs.aws.amazon.com/redshift/latest/dg/CONVERT_TIMEZONE.html), but dbt's dispatch was calling the postgres implementation per its search ordering, but the postgres implementation does not work in redshift. 

I consulted the dbt docs to see the best way to handle this and [they recommend implementing a redshift dispatch which simply calls the default implementation in cases like this](https://docs.getdbt.com/reference/dbt-jinja-functions/dispatch) (bottom of page) which seemed reasonable to me. Hence this PR! And thanks again for the package 😄 