### PR TITLE
Remove references to deprecated dbt-utils cross-db macros

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -8,7 +8,7 @@ clean-targets: ["target", "dbt_packages"]
 macro-paths: ["macros"]
 log-path: "logs"
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.2.0", "<2.0.0"]
 profile: integration_tests
 
 quoting:

--- a/integration_tests/macros/get_test_dates.sql
+++ b/integration_tests/macros/get_test_dates.sql
@@ -19,8 +19,8 @@ select
     'November' as month_name,
     'Nov' as month_name_short,
     1623076520 as unix_epoch,
-    cast('{{ get_test_timestamps()[0] }}' as {{ dbt_utils.type_timestamp() }}) as time_stamp,
-    cast('{{ get_test_timestamps()[1] }}' as {{ dbt_utils.type_timestamp() }}) as time_stamp_utc
+    cast('{{ get_test_timestamps()[0] }}' as {{ type_timestamp() }}) as time_stamp,
+    cast('{{ get_test_timestamps()[1] }}' as {{ type_timestamp() }}) as time_stamp_utc
 
 union all
 
@@ -44,8 +44,8 @@ select
     'Dec' as month_name_short,
     {# 1623051320 as unix_epoch, #}
     1623076520 as unix_epoch,
-    cast('{{ get_test_timestamps()[0] }}' as {{ dbt_utils.type_timestamp() }}) as time_stamp,
-    cast('{{ get_test_timestamps()[1] }}' as {{ dbt_utils.type_timestamp() }}) as time_stamp_utc
+    cast('{{ get_test_timestamps()[0] }}' as {{ type_timestamp() }}) as time_stamp,
+    cast('{{ get_test_timestamps()[1] }}' as {{ type_timestamp() }}) as time_stamp_utc
 
 {%- endmacro %}
 

--- a/macros/calendar_date/convert_timezone.sql
+++ b/macros/calendar_date/convert_timezone.sql
@@ -6,9 +6,9 @@
 
 {% macro default__convert_timezone(column, target_tz, source_tz) -%}
 {%- if not source_tz -%}
-cast(convert_timezone('{{ target_tz }}', {{ column }}) as {{ dbt_utils.type_timestamp() }})
+cast(convert_timezone('{{ target_tz }}', {{ column }}) as {{ type_timestamp() }})
 {%- else -%}
-cast(convert_timezone('{{ source_tz }}', '{{ target_tz }}', {{ column }}) as {{ dbt_utils.type_timestamp() }})
+cast(convert_timezone('{{ source_tz }}', '{{ target_tz }}', {{ column }}) as {{ type_timestamp() }})
 {%- endif -%}
 {%- endmacro -%}
 
@@ -25,9 +25,9 @@ from_utc_timestamp(
 
 {% macro postgres__convert_timezone(column, target_tz, source_tz) -%}
 {%- if source_tz -%}
-cast({{ column }} at time zone '{{ source_tz }}' at time zone '{{ target_tz }}' as {{ dbt_utils.type_timestamp() }})
+cast({{ column }} at time zone '{{ source_tz }}' at time zone '{{ target_tz }}' as {{ type_timestamp() }})
 {%- else -%}
-cast({{ column }} at time zone '{{ target_tz }}' as {{ dbt_utils.type_timestamp() }})
+cast({{ column }} at time zone '{{ target_tz }}' as {{ type_timestamp() }})
 {%- endif -%}
 {%- endmacro -%}
 

--- a/macros/calendar_date/day_of_month.sql
+++ b/macros/calendar_date/day_of_month.sql
@@ -3,5 +3,5 @@
 {%- endmacro %}
 
 {%- macro redshift__day_of_month(date) -%}
-cast({{ dbt_date.date_part('day', date) }} as {{ dbt_utils.type_bigint() }})
+cast({{ dbt_date.date_part('day', date) }} as {{ type_bigint() }})
 {%- endmacro %}

--- a/macros/calendar_date/day_of_week.sql
+++ b/macros/calendar_date/day_of_week.sql
@@ -57,11 +57,11 @@
     {%- if isoweek -%}
         {%- set dow_part = 'isodow' -%}
         -- Monday(1) to Sunday (7)
-        cast({{ dbt_date.date_part(dow_part, date) }} as {{ dbt_utils.type_int() }})
+        cast({{ dbt_date.date_part(dow_part, date) }} as {{ type_int() }})
     {%- else -%}
         {%- set dow_part = 'dow' -%}
         -- Sunday(1) to Saturday (7)
-        cast({{ dbt_date.date_part(dow_part, date) }} + 1 as {{ dbt_utils.type_int() }})
+        cast({{ dbt_date.date_part(dow_part, date) }} + 1 as {{ type_int() }})
     {%- endif -%}
 
 {%- endmacro %}
@@ -75,10 +75,10 @@
     case
         -- Shift start of week from Sunday (0) to Monday (1)
         when {{ dow }} = 0 then 7
-        else cast({{ dow }} as {{ dbt_utils.type_bigint() }})
+        else cast({{ dow }} as {{ type_bigint() }})
     end
     {%- else -%}
-    cast({{ dow }} + 1 as {{ dbt_utils.type_bigint() }})
+    cast({{ dow }} + 1 as {{ type_bigint() }})
     {%- endif -%}
 
 {%- endmacro %}

--- a/macros/calendar_date/day_of_year.sql
+++ b/macros/calendar_date/day_of_year.sql
@@ -11,5 +11,5 @@
 {%- endmacro %}
 
 {%- macro redshift__day_of_year(date) -%}
-    cast({{ dbt_date.date_part('dayofyear', date) }} as {{ dbt_utils.type_bigint() }})
+    cast({{ dbt_date.date_part('dayofyear', date) }} as {{ type_bigint() }})
 {%- endmacro %}

--- a/macros/calendar_date/iso_week_of_year.sql
+++ b/macros/calendar_date/iso_week_of_year.sql
@@ -4,7 +4,7 @@
 {%- endmacro -%}
 
 {%- macro _iso_week_of_year(date, week_type) -%}
-cast({{ dbt_date.date_part(week_type, date) }} as {{ dbt_utils.type_int() }})
+cast({{ dbt_date.date_part(week_type, date) }} as {{ type_int() }})
 {%- endmacro %}
 
 {%- macro default__iso_week_of_year(date) -%}

--- a/macros/calendar_date/iso_week_start.sql
+++ b/macros/calendar_date/iso_week_start.sql
@@ -4,7 +4,7 @@
 {%- endmacro -%}
 
 {%- macro _iso_week_start(date, week_type) -%}
-cast({{ dbt_utils.date_trunc(week_type, date) }} as date)
+cast({{ date_trunc(week_type, date) }} as date)
 {%- endmacro %}
 
 {%- macro default__iso_week_start(date) -%}

--- a/macros/calendar_date/n_days_ago.sql
+++ b/macros/calendar_date/n_days_ago.sql
@@ -1,5 +1,5 @@
 {%- macro n_days_ago(n, date=None, tz=None) -%}
 {%-set dt = date if date else dbt_date.today(tz) -%}
 {%- set n = n|int -%}
-cast({{ dbt_utils.dateadd('day', -1 * n, dt) }} as date)
+cast({{ dateadd('day', -1 * n, dt) }} as date)
 {%- endmacro -%}

--- a/macros/calendar_date/n_months_ago.sql
+++ b/macros/calendar_date/n_months_ago.sql
@@ -1,7 +1,7 @@
 {%- macro n_months_ago(n, tz=None) -%}
 {%- set n = n|int -%}
-{{ dbt_utils.date_trunc('month', 
-    dbt_utils.dateadd('month', -1 * n, 
+{{ date_trunc('month',
+    dateadd('month', -1 * n,
         dbt_date.today(tz)
         )
     ) }}

--- a/macros/calendar_date/n_months_away.sql
+++ b/macros/calendar_date/n_months_away.sql
@@ -1,7 +1,7 @@
 {%- macro n_months_away(n, tz=None) -%}
 {%- set n = n|int -%}
-{{ dbt_utils.date_trunc('month', 
-    dbt_utils.dateadd('month', n, 
+{{ date_trunc('month',
+    dateadd('month', n,
         dbt_date.today(tz)
         )
     ) }}

--- a/macros/calendar_date/n_weeks_ago.sql
+++ b/macros/calendar_date/n_weeks_ago.sql
@@ -1,7 +1,7 @@
 {%- macro n_weeks_ago(n, tz=None) -%}
 {%- set n = n|int -%}
-{{ dbt_utils.date_trunc('week', 
-    dbt_utils.dateadd('week', -1 * n, 
+{{ date_trunc('week',
+    dateadd('week', -1 * n,
         dbt_date.today(tz)
         )
     ) }}

--- a/macros/calendar_date/n_weeks_away.sql
+++ b/macros/calendar_date/n_weeks_away.sql
@@ -1,7 +1,7 @@
 {%- macro n_weeks_away(n, tz=None) -%}
 {%- set n = n|int -%}
-{{ dbt_utils.date_trunc('week', 
-    dbt_utils.dateadd('week', n, 
+{{ date_trunc('week',
+    dateadd('week', n,
         dbt_date.today(tz)
         )
     ) }}

--- a/macros/calendar_date/now.sql
+++ b/macros/calendar_date/now.sql
@@ -1,3 +1,3 @@
 {%- macro now(tz=None) -%}
-{{ dbt_date.convert_timezone(dbt_utils.current_timestamp(), tz) }}
+{{ dbt_date.convert_timezone(current_timestamp(), tz) }}
 {%- endmacro -%}

--- a/macros/calendar_date/now.sql
+++ b/macros/calendar_date/now.sql
@@ -1,3 +1,19 @@
 {%- macro now(tz=None) -%}
-{{ dbt_date.convert_timezone(current_timestamp(), tz) }}
+{{ dbt_date.convert_timezone(dbt_date.current_timestamp(), tz) }}
 {%- endmacro -%}
+
+{% macro current_timestamp() -%}
+  {{ return(adapter.dispatch('current_timestamp', 'dbt_date')()) }}
+{%- endmacro %}
+
+{% macro default__current_timestamp() %}
+    current_timestamp::{{ type_timestamp() }}
+{% endmacro %}
+
+{% macro redshift__current_timestamp() %}
+    getdate()
+{% endmacro %}
+
+{% macro bigquery__current_timestamp() %}
+    current_timestamp
+{% endmacro %}

--- a/macros/calendar_date/periods_since.sql
+++ b/macros/calendar_date/periods_since.sql
@@ -1,3 +1,3 @@
 {%- macro periods_since(date_col, period_name='day', tz=None) -%}
-{{ dbt_utils.datediff(date_col, dbt_date.now(tz), period_name) }}
+{{ datediff(date_col, dbt_date.now(tz), period_name) }}
 {%- endmacro -%}

--- a/macros/calendar_date/week_end.sql
+++ b/macros/calendar_date/week_end.sql
@@ -4,7 +4,7 @@
 {%- endmacro -%}
 
 {%- macro default__week_end(date) -%}
-{{ dbt_utils.last_day(date, 'week') }}
+{{ last_day(date, 'week') }}
 {%- endmacro %}
 
 {%- macro snowflake__week_end(date) -%}

--- a/macros/calendar_date/week_of_year.sql
+++ b/macros/calendar_date/week_of_year.sql
@@ -4,11 +4,11 @@
 {%- endmacro -%}
 
 {%- macro default__week_of_year(date) -%}
-cast({{ dbt_date.date_part('week', date) }} as {{ dbt_utils.type_int() }})
+cast({{ dbt_date.date_part('week', date) }} as {{ type_int() }})
 {%- endmacro %}
 
 {%- macro postgres__week_of_year(date) -%}
 {# postgresql 'week' returns isoweek. Use to_char instead.
    WW = the first week starts on the first day of the year #}
-cast(to_char({{ date }}, 'WW') as {{ dbt_utils.type_int() }})
+cast(to_char({{ date }}, 'WW') as {{ type_int() }})
 {%- endmacro %}

--- a/macros/calendar_date/week_start.sql
+++ b/macros/calendar_date/week_start.sql
@@ -4,7 +4,7 @@
 {%- endmacro -%}
 
 {%- macro default__week_start(date) -%}
-cast({{ dbt_utils.date_trunc('week', date) }} as date)
+cast({{ date_trunc('week', date) }} as date)
 {%- endmacro %}
 
 {%- macro snowflake__week_start(date) -%}
@@ -13,10 +13,10 @@ cast({{ dbt_utils.date_trunc('week', date) }} as date)
         dbt_date.day_of_week returns 1, so we subtract 1 to get a 0 offset
     #}
     {% set off_set = dbt_date.day_of_week(date, isoweek=False) ~ " - 1" %}
-    cast({{ dbt_utils.dateadd("day", "-1 * (" ~ off_set ~ ")", date) }} as date)
+    cast({{ dateadd("day", "-1 * (" ~ off_set ~ ")", date) }} as date)
 {%- endmacro %}
 
 {%- macro postgres__week_start(date) -%}
 -- Sunday as week start date
-cast({{ dbt_utils.dateadd('day', -1, dbt_utils.date_trunc('week', dbt_utils.dateadd('day', 1, date))) }} as date)
+cast({{ dateadd('day', -1, date_trunc('week', dateadd('day', 1, date))) }} as date)
 {%- endmacro %}

--- a/macros/fiscal_date/get_fiscal_periods.sql
+++ b/macros/fiscal_date/get_fiscal_periods.sql
@@ -1,5 +1,5 @@
 {% macro get_fiscal_periods(dates, year_end_month, week_start_day, shift_year=1) %}
-{# 
+{#
 This macro requires you to pass in a ref to a date dimension, created via
 dbt_date.get_date_dimension()s
 #}
@@ -13,14 +13,14 @@ fscl_year_w13 as (
         -- We count the weeks in a 13 week period
         -- and separate the 4-5-4 week sequences
         mod(cast(
-            (f.fiscal_week_of_year-1) as {{ dbt_utils.type_int() }}
+            (f.fiscal_week_of_year-1) as {{ type_int() }}
             ), 13) as w13_number,
         -- Chop weeks into 13 week merch quarters
         cast(
             least(
                 floor((f.fiscal_week_of_year-1)/13.0)
                 , 3)
-            as {{ dbt_utils.type_int() }}) as quarter_number
+            as {{ type_int() }}) as quarter_number
     from
         fscl_year_dates_for_periods f
 
@@ -33,7 +33,7 @@ fscl_periods as (
         f.week_start_date,
         f.week_end_date,
         f.fiscal_week_of_year,
-        case 
+        case
             -- we move week 53 into the 3rd period of the quarter
             when f.fiscal_week_of_year = 53 then 3
             when f.w13_number between 0 and 3 then 1
@@ -51,7 +51,7 @@ fscl_periods_quarters as (
         f.*,
         cast((
             (f.quarter_number * 3) + f.period_of_quarter
-         ) as {{ dbt_utils.type_int() }}) as fiscal_period_number
+         ) as {{ type_int() }}) as fiscal_period_number
     from
         fscl_periods f
 
@@ -61,12 +61,12 @@ select
     fiscal_year_number,
     week_start_date,
     week_end_date,
-    fiscal_week_of_year, 
+    fiscal_week_of_year,
     dense_rank() over(partition by fiscal_period_number order by fiscal_week_of_year) as fiscal_week_of_period,
     fiscal_period_number,
     quarter_number+1 as fiscal_quarter_number,
     period_of_quarter as fiscal_period_of_quarter
-from 
-    fscl_periods_quarters 
+from
+    fscl_periods_quarters
 order by 1,2
 {% endmacro %}

--- a/macros/fiscal_date/get_fiscal_year_dates.sql
+++ b/macros/fiscal_date/get_fiscal_year_dates.sql
@@ -27,7 +27,7 @@ weeks as (
         d.year_number,
         d.month_of_year,
         d.date_day as week_start_date,
-        cast({{ dbt_utils.dateadd('day', 6, 'd.date_day') }} as date) as week_end_date
+        cast({{ dateadd('day', 6, 'd.date_day') }} as date) as week_end_date
     from
         date_dimension d
     where
@@ -58,7 +58,7 @@ weeks_at_month_end as (
         rank() over
             (partition by d.fiscal_year_number
                 order by
-                abs({{ dbt_utils.datediff('d.week_end_date', 'm.month_end_date', 'day') }})
+                abs({{ datediff('d.week_end_date', 'm.month_end_date', 'day') }})
 
             ) as closest_to_month_end
     from
@@ -71,7 +71,7 @@ fiscal_year_range as (
     select
         w.fiscal_year_number,
         cast(
-            {{ dbt_utils.dateadd('day', 1,
+            {{ dateadd('day', 1,
             'lag(w.week_end_date) over(order by w.week_end_date)') }}
             as date) as fiscal_year_start_date,
         w.week_end_date as fiscal_year_end_date

--- a/macros/get_base_dates.sql
+++ b/macros/get_base_dates.sql
@@ -5,12 +5,12 @@
 {% macro default__get_base_dates(start_date, end_date, n_dateparts, datepart) %}
 
 {%- if start_date and end_date -%}
-{%- set start_date="cast('" ~ start_date ~ "' as " ~ dbt_utils.type_timestamp() ~ ")" -%}
-{%- set end_date="cast('" ~ end_date ~ "' as " ~ dbt_utils.type_timestamp() ~ ")"  -%}
+{%- set start_date="cast('" ~ start_date ~ "' as " ~ type_timestamp() ~ ")" -%}
+{%- set end_date="cast('" ~ end_date ~ "' as " ~ type_timestamp() ~ ")"  -%}
 
 {%- elif n_dateparts and datepart -%}
 
-{%- set start_date = dbt_utils.dateadd(datepart, -1 * n_dateparts, dbt_date.today()) -%}
+{%- set start_date = dateadd(datepart, -1 * n_dateparts, dbt_date.today()) -%}
 {%- set end_date = dbt_date.tomorrow() -%}
 {%- endif -%}
 
@@ -26,7 +26,7 @@ with date_spine as
 
 )
 select
-    cast(d.date_{{ datepart }} as {{ dbt_utils.type_timestamp() }}) as date_{{ datepart }}
+    cast(d.date_{{ datepart }} as {{ type_timestamp() }}) as date_{{ datepart }}
 from
     date_spine d
 {% endmacro %}
@@ -39,7 +39,7 @@ from
 
 {%- elif n_dateparts and datepart -%}
 
-{%- set start_date = dbt_utils.dateadd(datepart, -1 * n_dateparts, dbt_date.today()) -%}
+{%- set start_date = dateadd(datepart, -1 * n_dateparts, dbt_date.today()) -%}
 {%- set end_date = dbt_date.tomorrow() -%}
 {%- endif -%}
 
@@ -55,7 +55,7 @@ with date_spine as
 
 )
 select
-    cast(d.date_{{ datepart }} as {{ dbt_utils.type_timestamp() }}) as date_{{ datepart }}
+    cast(d.date_{{ datepart }} as {{ type_timestamp() }}) as date_{{ datepart }}
 from
     date_spine d
 {% endmacro %}

--- a/macros/get_date_dimension.sql
+++ b/macros/get_date_dimension.sql
@@ -10,8 +10,8 @@ dates_with_prior_year_dates as (
 
     select
         cast(d.date_day as date) as date_day,
-        cast({{ dbt_utils.dateadd('year', -1 , 'd.date_day') }} as date) as prior_year_date_day,
-        cast({{ dbt_utils.dateadd('day', -364 , 'd.date_day') }} as date) as prior_year_over_year_date_day
+        cast({{ dateadd('year', -1 , 'd.date_day') }} as date) as prior_year_date_day,
+        cast({{ dateadd('day', -364 , 'd.date_day') }} as date) as prior_year_over_year_date_day
     from
     	base_dates d
 
@@ -44,23 +44,23 @@ select
     {{ dbt_date.week_of_year('d.prior_year_over_year_date_day') }} as prior_year_week_of_year,
     {{ dbt_date.iso_week_of_year('d.prior_year_over_year_date_day') }} as prior_year_iso_week_of_year,
 
-    cast({{ dbt_date.date_part('month', 'd.date_day') }} as {{ dbt_utils.type_int() }}) as month_of_year,
+    cast({{ dbt_date.date_part('month', 'd.date_day') }} as {{ type_int() }}) as month_of_year,
     {{ dbt_date.month_name('d.date_day', short=false) }}  as month_name,
     {{ dbt_date.month_name('d.date_day', short=true) }}  as month_name_short,
 
-    cast({{ dbt_utils.date_trunc('month', 'd.date_day') }} as date) as month_start_date,
-    cast({{ dbt_utils.last_day('d.date_day', 'month') }} as date) as month_end_date,
+    cast({{ date_trunc('month', 'd.date_day') }} as date) as month_start_date,
+    cast({{ last_day('d.date_day', 'month') }} as date) as month_end_date,
 
-    cast({{ dbt_utils.date_trunc('month', 'd.prior_year_date_day') }} as date) as prior_year_month_start_date,
-    cast({{ dbt_utils.last_day('d.prior_year_date_day', 'month') }} as date) as prior_year_month_end_date,
+    cast({{ date_trunc('month', 'd.prior_year_date_day') }} as date) as prior_year_month_start_date,
+    cast({{ last_day('d.prior_year_date_day', 'month') }} as date) as prior_year_month_end_date,
 
-    cast({{ dbt_date.date_part('quarter', 'd.date_day') }} as {{ dbt_utils.type_int() }}) as quarter_of_year,
-    cast({{ dbt_utils.date_trunc('quarter', 'd.date_day') }} as date) as quarter_start_date,
-    cast({{ dbt_utils.last_day('d.date_day', 'quarter') }} as date) as quarter_end_date,
+    cast({{ dbt_date.date_part('quarter', 'd.date_day') }} as {{ type_int() }}) as quarter_of_year,
+    cast({{ date_trunc('quarter', 'd.date_day') }} as date) as quarter_start_date,
+    cast({{ last_day('d.date_day', 'quarter') }} as date) as quarter_end_date,
 
-    cast({{ dbt_date.date_part('year', 'd.date_day') }} as {{ dbt_utils.type_int() }}) as year_number,
-    cast({{ dbt_utils.date_trunc('year', 'd.date_day') }} as date) as year_start_date,
-    cast({{ dbt_utils.last_day('d.date_day', 'year') }} as date) as year_end_date
+    cast({{ dbt_date.date_part('year', 'd.date_day') }} as {{ type_int() }}) as year_number,
+    cast({{ date_trunc('year', 'd.date_day') }} as date) as year_start_date,
+    cast({{ last_day('d.date_day', 'year') }} as date) as year_end_date
 from
     dates_with_prior_year_dates d
 order by 1
@@ -74,8 +74,8 @@ dates_with_prior_year_dates as (
 
     select
         cast(d.date_day as date) as date_day,
-        cast({{ dbt_utils.dateadd('year', -1 , 'd.date_day') }} as date) as prior_year_date_day,
-        cast({{ dbt_utils.dateadd('day', -364 , 'd.date_day') }} as date) as prior_year_over_year_date_day
+        cast({{ dateadd('year', -1 , 'd.date_day') }} as date) as prior_year_date_day,
+        cast({{ dateadd('day', -364 , 'd.date_day') }} as date) as prior_year_over_year_date_day
     from
     	base_dates d
 
@@ -108,24 +108,24 @@ select
     {{ dbt_date.week_of_year('d.prior_year_over_year_date_day') }} as prior_year_week_of_year,
     {{ dbt_date.iso_week_of_year('d.prior_year_over_year_date_day') }} as prior_year_iso_week_of_year,
 
-    cast({{ dbt_date.date_part('month', 'd.date_day') }} as {{ dbt_utils.type_int() }}) as month_of_year,
+    cast({{ dbt_date.date_part('month', 'd.date_day') }} as {{ type_int() }}) as month_of_year,
     {{ dbt_date.month_name('d.date_day', short=false) }}  as month_name,
     {{ dbt_date.month_name('d.date_day', short=true) }}  as month_name_short,
 
-    cast({{ dbt_utils.date_trunc('month', 'd.date_day') }} as date) as month_start_date,
-    cast({{ dbt_utils.last_day('d.date_day', 'month') }} as date) as month_end_date,
+    cast({{ date_trunc('month', 'd.date_day') }} as date) as month_start_date,
+    cast({{ last_day('d.date_day', 'month') }} as date) as month_end_date,
 
-    cast({{ dbt_utils.date_trunc('month', 'd.prior_year_date_day') }} as date) as prior_year_month_start_date,
-    cast({{ dbt_utils.last_day('d.prior_year_date_day', 'month') }} as date) as prior_year_month_end_date,
+    cast({{ date_trunc('month', 'd.prior_year_date_day') }} as date) as prior_year_month_start_date,
+    cast({{ last_day('d.prior_year_date_day', 'month') }} as date) as prior_year_month_end_date,
 
-    cast({{ dbt_date.date_part('quarter', 'd.date_day') }} as {{ dbt_utils.type_int() }}) as quarter_of_year,
-    cast({{ dbt_utils.date_trunc('quarter', 'd.date_day') }} as date) as quarter_start_date,
-    {# dbt_utils.last_day does not support quarter because postgresql does not support quarter interval. #}
-    cast({{dbt_utils.dateadd('day', '-1', dbt_utils.dateadd('month', '3', dbt_utils.date_trunc('quarter', 'd.date_day')))}} as date) as quarter_end_date,
+    cast({{ dbt_date.date_part('quarter', 'd.date_day') }} as {{ type_int() }}) as quarter_of_year,
+    cast({{ date_trunc('quarter', 'd.date_day') }} as date) as quarter_start_date,
+    {# last_day does not support quarter because postgresql does not support quarter interval. #}
+    cast({{dateadd('day', '-1', dateadd('month', '3', date_trunc('quarter', 'd.date_day')))}} as date) as quarter_end_date,
 
-    cast({{ dbt_date.date_part('year', 'd.date_day') }} as {{ dbt_utils.type_int() }}) as year_number,
-    cast({{ dbt_utils.date_trunc('year', 'd.date_day') }} as date) as year_start_date,
-    cast({{ dbt_utils.last_day('d.date_day', 'year') }} as date) as year_end_date
+    cast({{ dbt_date.date_part('year', 'd.date_day') }} as {{ type_int() }}) as year_number,
+    cast({{ date_trunc('year', 'd.date_day') }} as date) as year_start_date,
+    cast({{ last_day('d.date_day', 'year') }} as date) as year_end_date
 from
     dates_with_prior_year_dates d
 order by 1

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<0.9.0"]
+    version: [">=0.9.0", "<1.0.0"]


### PR DESCRIPTION
Closes #78 

Requires dbt-utils [PR #650](https://github.com/dbt-labs/dbt-utils/pull/650) to be merged.