### PR TITLE
feat: add round timestamp macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ To run the tests:
 - [next_week](#next_weektznone)
 - [now](#nowtznone)
 - [periods_since](#periods_sincedate_col-period_nameday-tznone)
+- [round_timestamp](#round_timestamptimestamp)
 - [to_unixtimestamp](#to_unixtimestamptimestamp)
 - [today](#todaytznone)
 - [tomorrow](#tomorrowdatenone-tznone)
@@ -621,6 +622,38 @@ or, optionally, you can override the default timezone:
 {{ dbt_date.periods_since("my_timestamp_column", period_name="minute", tz="UTC" }}
 ```
 
+### [round_timestamp](macros/calendar_date/round_timestamp.sql)(`timestamp`)
+
+Rounds the given timestamp or date to the nearest date (return type is `timestamp`).
+
+```sql
+select
+{{ dbt_date.round_timestamp("timestamp_col") }} as nearest_date
+...
+```
+
+A few examples:
+
+```sql
+{{ dbt_date.round_timestamp("'2022-02-05 18:45:15'")}}
+-- results in 2022-02-06
+```
+
+```sql
+{{ dbt_date.round_timestamp("'2022-02-05 11:45:15'")}}
+-- results in 2022-02-05
+```
+
+```sql
+{{ dbt_date.round_timestamp("'2022-02-05 12:00:00'")}}
+-- results in 2022-02-06
+```
+
+```sql
+{{ dbt_date.round_timestamp("'2022-02-05 00:00:00'")}}
+-- results in 2022-02-05
+```
+
 ### [to_unixtimestamp](macros/calendar_date/to_unixtimestamp.sql)(`timestamp`)
 
 Gets Unix timestamp (epochs) based on provided timestamp.
@@ -767,36 +800,4 @@ or, optionally, you can override the default timezone:
 
 ```sql
 {{ dbt_date.yesterday(tz="America/New_York") }} as date_yesterday
-```
-
-### [round_timestamp](macros/calendar_date/round_timestamp.sql)(`field`)
-
-Rounds the given timestamp or date to the nearest date.
-
-```sql
-select
-{{ dbt_date.round_timestamp("timestamp_col") }} as nearest_date
-...
-```
-
-A few examples:
-
-```sql
-{{ dbt_date.round_timestamp("'2022-02-05 18:45:15'")}}
--- results in 2022-02-06
-```
-
-```sql
-{{ dbt_date.round_timestamp("'2022-02-05 11:45:15'")}}
--- results in 2022-02-05
-```
-
-```sql
-{{ dbt_date.round_timestamp("'2022-02-05 12:00:00'")}}
--- results in 2022-02-06
-```
-
-```sql
-{{ dbt_date.round_timestamp("'2022-02-05 00:00:00'")}}
--- results in 2022-02-05
 ```

--- a/README.md
+++ b/README.md
@@ -768,3 +768,35 @@ or, optionally, you can override the default timezone:
 ```sql
 {{ dbt_date.yesterday(tz="America/New_York") }} as date_yesterday
 ```
+
+### [round_timestamp](macros/calendar_date/round_timestamp.sql)(`field`)
+
+Rounds the given timestamp or date to the nearest date.
+
+```sql
+select
+{{ dbt_date.round_timestamp("timestamp_col") }} as nearest_date
+...
+```
+
+A few examples:
+
+```sql
+{{ dbt_date.round_timestamp("'2022-02-05 18:45:15'")}}
+-- results in 2022-02-06
+```
+
+```sql
+{{ dbt_date.round_timestamp("'2022-02-05 11:45:15'")}}
+-- results in 2022-02-05
+```
+
+```sql
+{{ dbt_date.round_timestamp("'2022-02-05 12:00:00'")}}
+-- results in 2022-02-06
+```
+
+```sql
+{{ dbt_date.round_timestamp("'2022-02-05 00:00:00'")}}
+-- results in 2022-02-05
+```

--- a/integration_tests/macros/get_test_dates.sql
+++ b/integration_tests/macros/get_test_dates.sql
@@ -21,8 +21,8 @@ select
     1623076520 as unix_epoch,
     cast('{{ get_test_timestamps()[0] }}' as {{ type_timestamp() }}) as time_stamp,
     cast('{{ get_test_timestamps()[1] }}' as {{ type_timestamp() }}) as time_stamp_utc,
-    cast('2021-06-07' as date) as rounded_timestamp,
-    cast('2021-06-08' as date) as rounded_timestamp_utc
+    cast('2021-06-07' as {{ type_timestamp() }}) as rounded_timestamp,
+    cast('2021-06-08' as {{ type_timestamp() }}) as rounded_timestamp_utc
 
 union all
 
@@ -48,8 +48,8 @@ select
     1623076520 as unix_epoch,
     cast('{{ get_test_timestamps()[0] }}' as {{ type_timestamp() }}) as time_stamp,
     cast('{{ get_test_timestamps()[1] }}' as {{ type_timestamp() }}) as time_stamp_utc,
-    cast('2021-06-07' as date) as rounded_timestamp,
-    cast('2021-06-08' as date) as rounded_timestamp_utc
+    cast('2021-06-07' as {{ type_timestamp() }}) as rounded_timestamp,
+    cast('2021-06-08' as {{ type_timestamp() }}) as rounded_timestamp_utc
 
 {%- endmacro %}
 

--- a/integration_tests/macros/get_test_dates.sql
+++ b/integration_tests/macros/get_test_dates.sql
@@ -20,7 +20,9 @@ select
     'Nov' as month_name_short,
     1623076520 as unix_epoch,
     cast('{{ get_test_timestamps()[0] }}' as {{ type_timestamp() }}) as time_stamp,
-    cast('{{ get_test_timestamps()[1] }}' as {{ type_timestamp() }}) as time_stamp_utc
+    cast('{{ get_test_timestamps()[1] }}' as {{ type_timestamp() }}) as time_stamp_utc,
+    cast('2021-06-07' as date) as rounded_timestamp,
+    cast('2021-06-08' as date) as rounded_timestamp_utc
 
 union all
 
@@ -45,7 +47,9 @@ select
     {# 1623051320 as unix_epoch, #}
     1623076520 as unix_epoch,
     cast('{{ get_test_timestamps()[0] }}' as {{ type_timestamp() }}) as time_stamp,
-    cast('{{ get_test_timestamps()[1] }}' as {{ type_timestamp() }}) as time_stamp_utc
+    cast('{{ get_test_timestamps()[1] }}' as {{ type_timestamp() }}) as time_stamp_utc,
+    cast('2021-06-07' as date) as rounded_timestamp,
+    cast('2021-06-08' as date) as rounded_timestamp_utc
 
 {%- endmacro %}
 

--- a/integration_tests/models/test_dates.yml
+++ b/integration_tests/models/test_dates.yml
@@ -37,6 +37,10 @@ models:
             expression: "unix_epoch = {{ dbt_date.to_unixtimestamp('time_stamp_utc') }}"
         - dbt_utils.expression_is_true:
             expression: "time_stamp = {{ dbt_date.convert_timezone('time_stamp_utc') }}"
+        - dbt_utils.expression_is_true:
+            expression: "rounded_timestamp = {{ dbt_date.round_timestamp('time_stamp') }}"
+        - dbt_utils.expression_is_true:
+            expression: "rounded_timestamp_utc = {{ dbt_date.round_timestamp('time_stamp_utc') }}"
 
     columns:
       - name: date_day

--- a/macros/calendar_date/round_timestamp.sql
+++ b/macros/calendar_date/round_timestamp.sql
@@ -1,0 +1,3 @@
+{% macro round_timestamp(field) %}
+    {{ dbt_utils.date_trunc("day", dbt_utils.dateadd("'hour'", "12", field)) }}
+{% endmacro %}

--- a/macros/calendar_date/round_timestamp.sql
+++ b/macros/calendar_date/round_timestamp.sql
@@ -1,3 +1,3 @@
-{% macro round_timestamp(field) %}
-    {{ dbt_utils.date_trunc("day", dbt_utils.dateadd("'hour'", "12", field)) }}
+{% macro round_timestamp(timestamp) %}
+    {{ date_trunc("day", dateadd("hour", 12, timestamp)) }}
 {% endmacro %}


### PR DESCRIPTION
Small macro which I find helpful.

It's quite similar to the typical sql `date_trunc` in that it returns a date, but it returns the _closest_ date to a given timestamp.