### PR TITLE
Simplify convert from source_tz

### DIFF
--- a/integration_tests/models/test_dates.yml
+++ b/integration_tests/models/test_dates.yml
@@ -38,6 +38,12 @@ models:
         - dbt_utils.expression_is_true:
             expression: "time_stamp = {{ dbt_date.convert_timezone('time_stamp_utc') }}"
         - dbt_utils.expression_is_true:
+            expression: "time_stamp = {{ dbt_date.convert_timezone('time_stamp_utc', source_tz='UTC') }}"
+        # - dbt_utils.expression_is_true:
+        #     expression: "time_stamp_utc = {{ dbt_date.convert_timezone('time_stamp', source_tz='America/Los_Angeles', target_tz='UTC') }}"
+        # - dbt_utils.expression_is_true:
+        #     expression: "time_stamp = {{ dbt_date.convert_timezone('time_stamp', source_tz='America/Los_Angeles', target_tz='America/Los_Angeles') }}"
+        - dbt_utils.expression_is_true:
             expression: "rounded_timestamp = {{ dbt_date.round_timestamp('time_stamp') }}"
         - dbt_utils.expression_is_true:
             expression: "rounded_timestamp_utc = {{ dbt_date.round_timestamp('time_stamp_utc') }}"

--- a/macros/calendar_date/convert_timezone.sql
+++ b/macros/calendar_date/convert_timezone.sql
@@ -5,11 +5,9 @@
 {%- endmacro -%}
 
 {% macro default__convert_timezone(column, target_tz, source_tz) -%}
-{%- if not source_tz -%}
-cast(convert_timezone('{{ target_tz }}', {{ column }}) as {{ type_timestamp() }})
-{%- else -%}
-cast(convert_timezone('{{ source_tz }}', '{{ target_tz }}', {{ column }}) as {{ type_timestamp() }})
-{%- endif -%}
+convert_timezone('{{ source_tz }}', '{{ target_tz }}',
+    cast({{ column }} as {{ type_timestamp() }})
+)
 {%- endmacro -%}
 
 {%- macro bigquery__convert_timezone(column, target_tz, source_tz=None) -%}
@@ -24,11 +22,10 @@ from_utc_timestamp(
 {%- endmacro -%}
 
 {% macro postgres__convert_timezone(column, target_tz, source_tz) -%}
-{%- if source_tz -%}
-cast({{ column }} at time zone '{{ source_tz }}' at time zone '{{ target_tz }}' as {{ type_timestamp() }})
-{%- else -%}
-cast({{ column }} at time zone '{{ target_tz }}' as {{ type_timestamp() }})
-{%- endif -%}
+cast(
+    cast({{ column }} as {{ type_timestamp() }})
+        at time zone '{{ source_tz }}' at time zone '{{ target_tz }}' as {{ type_timestamp() }}
+)
 {%- endmacro -%}
 
 {%- macro redshift__convert_timezone(column, target_tz, source_tz) -%}


### PR DESCRIPTION
Fixes #85 

This PR
- simplifies the code in `convert_timezone` by removing paths that check for `source_tz`, since we always specify a default
- cast the column to timestamp (no timezone on platforms that support it) _before_ converting to avoid the issue referenced in #85 