### PR TITLE
Switch to dbt-core's implementation of current_timestamp()

### DIFF
--- a/macros/calendar_date/now.sql
+++ b/macros/calendar_date/now.sql
@@ -1,19 +1,3 @@
 {%- macro now(tz=None) -%}
-{{ dbt_date.convert_timezone(dbt_date.current_timestamp(), tz) }}
+{{ dbt_date.convert_timezone(current_timestamp(), tz) }}
 {%- endmacro -%}
-
-{% macro current_timestamp() -%}
-  {{ return(adapter.dispatch('current_timestamp', 'dbt_date')()) }}
-{%- endmacro %}
-
-{% macro default__current_timestamp() %}
-    current_timestamp::{{ type_timestamp() }}
-{% endmacro %}
-
-{% macro redshift__current_timestamp() %}
-    getdate()
-{% endmacro %}
-
-{% macro bigquery__current_timestamp() %}
-    current_timestamp
-{% endmacro %}


### PR DESCRIPTION
This removes the `current_timestamp` macro in favor of dbt's implementation. 

Closes #87 