### PR TITLE
Fix get_base_dates for BQ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       DBT_PROFILES_DIR: ./integration_tests/ci
       DBT_PROJECT_DIR: ./integration_tests
       BIGQUERY_SERVICE_KEY_PATH: "/home/circleci/bigquery-service-key.json"
-      DBT_VERSION: 1.4.1
+      DBT_VERSION: 1.6.0
 
     steps:
       - checkout

--- a/macros/get_base_dates.sql
+++ b/macros/get_base_dates.sql
@@ -34,8 +34,8 @@ from
 {% macro bigquery__get_base_dates(start_date, end_date, n_dateparts, datepart) %}
 
 {%- if start_date and end_date -%}
-{%- set start_date="cast('" ~ start_date ~ "' as date )" -%}
-{%- set end_date="cast('" ~ end_date ~ "' as date )" -%}
+{%- set start_date="cast('" ~ start_date ~ "' as datetime )" -%}
+{%- set end_date="cast('" ~ end_date ~ "' as datetime )" -%}
 
 {%- elif n_dateparts and datepart -%}
 


### PR DESCRIPTION
`get_base_dates` forces a cast to `date` for BQ, which breaks hourly models.