### PR TITLE
adding date() and datetime() short hand macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ For example, use `America/New_York` for East Coast Time.
 
 * [get_fiscal_periods](#get_fiscal_periodsdates-year_end_month-week_start_day-shift_year1)
 
+## Utils
+
+* [date](#dateyear-month-day)
+* [datetime](#datetimeyear-month-day-hour0-minute0-second0-microsecond0-tznone)
+
 ## Documentation
 
 ### [get_base_dates](macros/get_base_dates.sql)(`start_date=None, end_date=None, n_dateparts=None, datepart="day"`)
@@ -802,6 +807,30 @@ or, optionally, you can override the default timezone:
 
 ```sql
 {{ dbt_date.yesterday(tz="America/New_York") }} as date_yesterday
+```
+
+### [date](macros/_utils/modules_datetime.sql)(`year`, `month`, `day`)
+
+Reduces the boilerplate syntax required to produce a `date` object. This is not converted to a string to allow pythonic manipulation.
+
+Usage:
+```sql
+{% set date_object = dbt_date.date(1997, 9, 29) %}
+```
+
+### [datetime](macros/_utils/modules_datetime.sql)(`year`, `month`, `day`, `hour=0`, `minute=0`, `second=0`, `microsecond=0`, `tz=None`)
+
+Reduces the boilerplate syntax required to produce a `datetime` object. This is not converted to a string to allow pythonic manipulation.
+
+Usage:
+```sql
+{% set datetime_object = dbt_date.datetime(1997, 9, 29, 6, 14) %}
+```
+
+or, optionally, you can override the default timezone:
+
+```sql
+{% set datetime_object = dbt_date.datetime(1997, 9, 29, 6, 14, tz='America/New_York') %}
 ```
 
 ## Integration Tests (Developers Only)

--- a/integration_tests/macros/get_test_dates.sql
+++ b/integration_tests/macros/get_test_dates.sql
@@ -30,7 +30,9 @@ select
     {{ dbt_date.last_month_name(short=True) }} as last_month_name_short,
     {{ dbt_date.next_month_number() }} as next_month_number,
     {{ dbt_date.next_month_name(short=False) }} as next_month_name,
-    {{ dbt_date.next_month_name(short=True) }} as next_month_name_short
+    {{ dbt_date.next_month_name(short=True) }} as next_month_name_short,
+    {{ modules.datetime.date(1997, 9, 29) }} as datetime_date,
+    {{ modules.datetime.datetime(1997, 9, 29, 6, 14, modules.pytz.timezone(var("dbt_date:time_zone"))) }} as datetime_datetime
 
 union all
 
@@ -64,7 +66,9 @@ select
     {{ dbt_date.last_month_name(short=True) }} as last_month_name_short,
     {{ dbt_date.next_month_number() }} as next_month_number,
     {{ dbt_date.next_month_name(short=False) }} as next_month_name,
-    {{ dbt_date.next_month_name(short=True) }} as next_month_name_short
+    {{ dbt_date.next_month_name(short=True) }} as next_month_name_short,
+    {{ modules.datetime.date(1997, 9, 29) }} as datetime_date,
+    {{ modules.datetime.datetime(1997, 9, 29, 6, 14, modules.pytz.timezone(var("dbt_date:time_zone"))) }} as datetime_datetime
 
 {%- endmacro %}
 

--- a/integration_tests/macros/get_test_dates.sql
+++ b/integration_tests/macros/get_test_dates.sql
@@ -31,8 +31,8 @@ select
     {{ dbt_date.next_month_number() }} as next_month_number,
     {{ dbt_date.next_month_name(short=False) }} as next_month_name,
     {{ dbt_date.next_month_name(short=True) }} as next_month_name_short,
-    '{{ modules.datetime.date(1997, 9, 29) }}' as datetime_date,
-    '{{ modules.datetime.datetime(1997, 9, 29, 6, 14, 0, tzinfo=modules.pytz.timezone(var("dbt_date:time_zone"))) }}' as datetime_datetime
+    cast('{{ modules.datetime.date(1997, 9, 29) }}' as date) as datetime_date,
+    cast('{{ modules.datetime.datetime(1997, 9, 29, 6, 14, 0, tzinfo=modules.pytz.timezone(var("dbt_date:time_zone"))) }}' as {{ dbt.type_timestamp() }}) as datetime_datetime
 
 union all
 
@@ -67,8 +67,8 @@ select
     {{ dbt_date.next_month_number() }} as next_month_number,
     {{ dbt_date.next_month_name(short=False) }} as next_month_name,
     {{ dbt_date.next_month_name(short=True) }} as next_month_name_short,
-    '{{ modules.datetime.date(1997, 9, 29) }}' as datetime_date,
-    '{{ modules.datetime.datetime(1997, 9, 29, 6, 14, 0, tzinfo=modules.pytz.timezone(var("dbt_date:time_zone"))) }}' as datetime_datetime
+    cast('{{ modules.datetime.date(1997, 9, 29) }}' as date) as datetime_date,
+    cast('{{ modules.datetime.datetime(1997, 9, 29, 6, 14, 0, tzinfo=modules.pytz.timezone(var("dbt_date:time_zone"))) }}' as {{ dbt.type_timestamp() }}) as datetime_datetime
 
 {%- endmacro %}
 

--- a/integration_tests/macros/get_test_dates.sql
+++ b/integration_tests/macros/get_test_dates.sql
@@ -31,8 +31,8 @@ select
     {{ dbt_date.next_month_number() }} as next_month_number,
     {{ dbt_date.next_month_name(short=False) }} as next_month_name,
     {{ dbt_date.next_month_name(short=True) }} as next_month_name_short,
-    {{ modules.datetime.date(1997, 9, 29) }} as datetime_date,
-    {{ modules.datetime.datetime(1997, 9, 29, 6, 14, modules.pytz.timezone(var("dbt_date:time_zone"))) }} as datetime_datetime
+    '{{ modules.datetime.date(1997, 9, 29) }}' as datetime_date,
+    '{{ modules.datetime.datetime(1997, 9, 29, 6, 14, 0, tzinfo=modules.pytz.timezone(var("dbt_date:time_zone"))) }}' as datetime_datetime
 
 union all
 
@@ -67,8 +67,8 @@ select
     {{ dbt_date.next_month_number() }} as next_month_number,
     {{ dbt_date.next_month_name(short=False) }} as next_month_name,
     {{ dbt_date.next_month_name(short=True) }} as next_month_name_short,
-    {{ modules.datetime.date(1997, 9, 29) }} as datetime_date,
-    {{ modules.datetime.datetime(1997, 9, 29, 6, 14, modules.pytz.timezone(var("dbt_date:time_zone"))) }} as datetime_datetime
+    '{{ modules.datetime.date(1997, 9, 29) }}' as datetime_date,
+    '{{ modules.datetime.datetime(1997, 9, 29, 6, 14, 0, tzinfo=modules.pytz.timezone(var("dbt_date:time_zone"))) }}' as datetime_datetime
 
 {%- endmacro %}
 

--- a/integration_tests/models/test_dates.yml
+++ b/integration_tests/models/test_dates.yml
@@ -66,9 +66,9 @@ models:
         - expression_is_true:
             expression: "next_month_name_short = {{ dbt_date.next_month_name(short=True) }}"
         - expression_is_true:
-            expression: "datetime_date = {{ dbt_date.date(1997, 9, 29) }}"
+            expression: "datetime_date = cast('{{ dbt_date.date(1997, 9, 29) }}' as date)"
         - expression_is_true:
-            expression: "datetime_datetime = {{ dbt_date.datetime(1997, 9, 29, 6, 14) }}"
+            expression: "datetime_datetime = cast('{{ dbt_date.datetime(1997, 9, 29, 6, 14) }}' as {{ dbt.type_timestamp() }})"
 
 
     columns:

--- a/integration_tests/models/test_dates.yml
+++ b/integration_tests/models/test_dates.yml
@@ -65,6 +65,10 @@ models:
             expression: "next_month_name = {{ dbt_date.next_month_name(short=False) }}"
         - expression_is_true:
             expression: "next_month_name_short = {{ dbt_date.next_month_name(short=True) }}"
+        - expression_is_true:
+            expression: "datetime_date = {{ dbt_date.date(1997, 9, 29) }}"
+        - expression_is_true:
+            expression: "datetime_datetime = {{ dbt_date.datetime(1997, 9, 29, 6, 14) }}"
 
 
     columns:

--- a/macros/_utils/modules_datetime.sql
+++ b/macros/_utils/modules_datetime.sql
@@ -1,0 +1,15 @@
+{% macro date(year, month, day) %}
+    {{ return("'" ~ modules.datetime.date(year, month, day) ~ "'") }}
+{% endmacro %}
+
+{% macro datetime(year, month, day, hour=0, minute=0, second=0, microsecond=0, tz=None) %}
+    {% set tz = tz if tz else var("dbt_date:time_zone") %}
+    {{ return(
+        "'" ~
+        modules.datetime.datetime(
+            year=year, month=month, day=day, hour=hour,
+            minute=minute, second=second, microsecond=microsecond,
+            tzinfo=modules.pytz.timezone(tz)
+        ) ~ "'"
+    ) }}
+{% endmacro %}

--- a/macros/_utils/modules_datetime.sql
+++ b/macros/_utils/modules_datetime.sql
@@ -1,15 +1,14 @@
 {% macro date(year, month, day) %}
-    {{ return("'" ~ modules.datetime.date(year, month, day) ~ "'") }}
+    {{ return(modules.datetime.date(year, month, day)) }}
 {% endmacro %}
 
 {% macro datetime(year, month, day, hour=0, minute=0, second=0, microsecond=0, tz=None) %}
     {% set tz = tz if tz else var("dbt_date:time_zone") %}
     {{ return(
-        "'" ~
         modules.datetime.datetime(
             year=year, month=month, day=day, hour=hour,
             minute=minute, second=second, microsecond=microsecond,
             tzinfo=modules.pytz.timezone(tz)
-        ) ~ "'"
+        )
     ) }}
 {% endmacro %}

--- a/macros/_utils/short_hand.sql
+++ b/macros/_utils/short_hand.sql
@@ -1,7 +1,0 @@
-{% macro date(year, month, day) %}
-    {{ return(modules.datetime.date(year, month, day)) }}
-{% endmacro %}
-
-{% macro datetime(year, month, day, hour=0, minute=0, second=0, millisecond=0) %}
-    {{ return(modules.datetime.datetime(year, month, day, hour, minute, second, millisecond, modules.pytz.timezone(var("dbt_date:time_zone")))) }}
-{% endmacro %}

--- a/macros/_utils/short_hand.sql
+++ b/macros/_utils/short_hand.sql
@@ -1,0 +1,7 @@
+{% macro date(year, month, day) %}
+    {{ return(modules.datetime.date(year, month, day)) }}
+{% endmacro %}
+
+{% macro datetime(year, month, day, hour=0, minute=0, second=0, millisecond=0) %}
+    {{ return(modules.datetime.datetime(year, month, day, hour, minute, second, millisecond, modules.pytz.timezone(var("dbt_date:time_zone")))) }}
+{% endmacro %}


### PR DESCRIPTION
### Problem

It takes a lot of Jinja boilerplate to generate simple datetime objects.

```Jinja
{% set foo = modules.datetime.datetime(1997, 9, 29, 6, 14, tzinfo=modules.pytz.timezone('UTC')) %}
```

Compiles as `1997-09-29 06:14:00+00:00`

### Solution

The PR introduces `datetime()` and `date()` macros to reduce boilerplate and increase code readability.

```Jinja
{% set foo = dbt_date.datetime(1997, 9, 29, 6, 14) %}
```

Compiles as `1997-09-29 06:14:00+00:00`

This halves the character count to produce a `datetime` object.

The `datetime()` macro defaults to timezone from the `dbt_date:time_zone` project variable.

The `date()` macro doesn't reduce the Jinja boilerplate as much but it is useful for consistency.

```Jinja
{% set foo = dbt_date.date(1997, 9, 29) %}
```

Compiles as `1997-09-29`