### PR TITLE
Update dbt version for CI to 1.7.*

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       DBT_PROFILES_DIR: ./integration_tests/ci
       DBT_PROJECT_DIR: ./integration_tests
       BIGQUERY_SERVICE_KEY_PATH: "/home/circleci/bigquery-service-key.json"
-      DBT_VERSION: 1.6.*
+      DBT_VERSION: 1.7.*
 
     steps:
       - checkout
@@ -104,7 +104,7 @@ jobs:
     environment:
       DBT_PROFILES_DIR: ./integration_tests/ci
       DBT_PROJECT_DIR: ./integration_tests
-      DBT_VERSION: 1.6.*
+      DBT_VERSION: 1.7.*
 
     steps:
       - checkout
@@ -145,7 +145,7 @@ jobs:
     environment:
       DBT_PROFILES_DIR: ./integration_tests/ci
       DBT_PROJECT_DIR: ./integration_tests
-      DBT_VERSION: 1.6.*
+      DBT_VERSION: 1.7.*
 
     steps:
       - checkout

--- a/macros/calendar_date/from_unixtimestamp.sql
+++ b/macros/calendar_date/from_unixtimestamp.sql
@@ -69,4 +69,16 @@
         )
     }}
     {% endif -%}
+
+{%- endmacro %}
+
+
+{%- macro duckdb__from_unixtimestamp(epochs, format="seconds") -%}
+    {%- if format != "seconds" -%}
+    {{ exceptions.raise_compiler_error(
+        "value " ~ format ~ " for `format` for from_unixtimestamp is not supported."
+        )
+    }}
+    {% endif -%}
+    cast(to_timestamp({{ epochs }}) at time zone 'UTC' as timestamp)
 {%- endmacro %}


### PR DESCRIPTION
Also adds explicit epoch to timestamp conversion for duckdb (to pass tests using newer duckdb adapter).