### PR TITLE
Change marco month_name.sql

### DIFF
--- a/macros/calendar_date/month_name.sql
+++ b/macros/calendar_date/month_name.sql
@@ -33,7 +33,7 @@
 {%- endmacro %}
 
 {%- macro spark__month_name(date, short) -%}
-{%- set f = 'LLL' if short else 'LLLL' -%}
+{%- set f = 'MMM' if short else 'MMMM' -%}
     date_format({{ date }}, '{{ f }}')
 {%- endmacro %}
 


### PR DESCRIPTION
### Context:
For newer versions of spark (>3.0), using the month flag 'L' in the databricks related macros leads to errors as documented here: https://github.com/calogica/dbt-date/issues/119.
In the Spark documentation (https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html) it is stated that 
"'LLL': Short textual representation in the stand-alone form. It should be used to format/parse only months without any other date fields."
Whereas:
"'MMM': Short textual representation in the standard form. The month pattern should be a part of a date pattern not just a stand-alone month except locales where there is no difference between stand and stand-alone forms like in English."
Since the macro below is supposed to return the month name in a stand-alone form, the 'L' flag is probably also the preferred way to do this.

### Changes:
I propose to change the flag 'L' with 'M' for the databricks related macro "spark__month_name" since this resolve the issue

